### PR TITLE
[Feat/#38] interest category button 구현

### DIFF
--- a/src/components/common/buttons/InterestCategoryButton/InterestCategoryButton.style.ts
+++ b/src/components/common/buttons/InterestCategoryButton/InterestCategoryButton.style.ts
@@ -1,0 +1,30 @@
+import { Theme, css } from '@emotion/react';
+import { flexGenerator } from '@styles/generator';
+
+export const InterestCategoryButtonStyle = css`
+  ${flexGenerator()}
+  border: none;
+`;
+
+export const InterestCategoryButtonVariant = (theme: Theme) => ({
+  default: css`
+    display: flex;
+    width: 10.7rem;
+    height: 3.4rem;
+    padding: 0.5rem 1rem;
+    align-items: center;
+    justify-content: center;
+    gap: 0.4rem;
+    border-radius: 5px;
+    background-color: ${theme.color.purple6};
+    color: ${theme.color.purple2};
+    ${theme.font['body03-r-12']}
+
+    cursor: pointer;
+  `,
+});
+
+export const iconWrapperStyle = css`
+  width: 1.6rem;
+  height: 1.6rem;
+`;

--- a/src/components/common/buttons/InterestCategoryButton/InterestCategoryButton.tsx
+++ b/src/components/common/buttons/InterestCategoryButton/InterestCategoryButton.tsx
@@ -10,10 +10,17 @@ interface InterestCategoryButtonProps extends HTMLAttributes<HTMLButtonElement> 
   icon: React.ReactNode;
 }
 
-const InterestCategoryButton = ({ children, variant, icon }: InterestCategoryButtonProps) => {
+const InterestCategoryButton = ({
+  children,
+  variant,
+  icon,
+  onClick,
+}: InterestCategoryButtonProps) => {
   const theme = useTheme();
   return (
-    <button css={[InterestCategoryButtonStyle, InterestCategoryButtonVariant(theme)[variant]]}>
+    <button
+      css={[InterestCategoryButtonStyle, InterestCategoryButtonVariant(theme)[variant]]}
+      onClick={onClick}>
       <span css={iconWrapperStyle}>{icon}</span>
       {children}
     </button>

--- a/src/components/common/buttons/InterestCategoryButton/InterestCategoryButton.tsx
+++ b/src/components/common/buttons/InterestCategoryButton/InterestCategoryButton.tsx
@@ -1,0 +1,23 @@
+import { useTheme } from '@emotion/react';
+import {
+  InterestCategoryButtonStyle,
+  InterestCategoryButtonVariant,
+  iconWrapperStyle,
+} from './InterestCategoryButton.style';
+import { HTMLAttributes } from 'react';
+interface InterestCategoryButtonProps extends HTMLAttributes<HTMLButtonElement> {
+  variant: 'default';
+  icon: React.ReactNode;
+}
+
+const InterestCategoryButton = ({ children, variant, icon }: InterestCategoryButtonProps) => {
+  const theme = useTheme();
+  return (
+    <button css={[InterestCategoryButtonStyle, InterestCategoryButtonVariant(theme)[variant]]}>
+      <span css={iconWrapperStyle}>{icon}</span>
+      {children}
+    </button>
+  );
+};
+
+export default InterestCategoryButton;


### PR DESCRIPTION
<!-- PR의 제목은 "[Feat/#1] 로그인 기능 추가" 와 같이 작성해주세요! -->

## 📌 관련 이슈번호

- Closes #38 
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

## ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 내용
   - interest category button 구현하였습니다.

## 📢 To Reviewers

- 태승님께서 말씀해주셨는데, 버튼의 모양은 category를 variant로 가진 Label 컴포넌트와 크기만 다르고 흡사합니다.
- 그러나 이  interest category button은 onClick이 있어야 하므로 따로 분리하여 진행하였습니다. 

## 📸 스크린샷

<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->
![image](https://github.com/PICK-PLE/PICKPLE-client/assets/126966681/4ed84632-5e2a-4332-933f-399c3a49e651)
