### PR TITLE
[Setting/#69] Dev페이지 레이아웃

### DIFF
--- a/src/pages/dev/Dev.style.ts
+++ b/src/pages/dev/Dev.style.ts
@@ -1,16 +1,5 @@
 import { css } from '@emotion/react';
-import { flexGenerator } from '@styles/generator';
 
-//테스트를 위해 컴포넌트 끼리의 간격만을 조정하기 위한 스타일입니다.
-export const payButtonsStyle = () => css`
-  ${flexGenerator()}
-  padding: 1rem 0;
-`;
-
-export const socialLoginButtonStyle = () => css`
-  padding: 1rem 0;
-`;
-
-export const simpleUserProfileStyle = () => css`
-  padding: 1rem 0;
+export const devContainer = css`
+  padding: 0 2rem;
 `;

--- a/src/pages/dev/Dev.tsx
+++ b/src/pages/dev/Dev.tsx
@@ -1,5 +1,17 @@
+import { ProgressBar } from '@components';
+import LogoHeader from 'src/components/common/headers/LogoHeader/LogoHeader';
+import { devContainer } from './Dev.style';
+
 const Dev = () => {
-  return <></>;
+  return (
+    <>
+      <LogoHeader />
+      <ProgressBar progress={77} />
+      <section css={devContainer}>
+        {/* 여기에 컴포넌트 추가해보고, 디바이스 크기 조정해보면서 테스트 */}
+      </section>
+    </>
+  );
 };
 
 export default Dev;

--- a/src/styles/global.ts
+++ b/src/styles/global.ts
@@ -30,7 +30,7 @@ const GlobalStyle = css`
     width: 100%;
     min-width: var(--min-width);
     max-width: var(--max-width);
-    min-height: 100vh;
+    min-height: 100dvh;
     background-color: #fff;
     margin: 0 auto;
   }


### PR DESCRIPTION
<!-- PR의 제목은 "[Feat/#1] 로그인 기능 추가" 와 같이 작성해주세요! -->

## 📌 관련 이슈번호

- Closes #69
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

## ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 뷰포트 설정
  - vh -> dvh
  참고: [[CSS] dvh, lvh, svh / dvw, lvw, svw 알아보기](https://arc.net/l/quote/qumqyexk)
  
2. dev페이지 레이아웃 설정
  - 페이지 기본 padding 추가해놓음.


## 📢 To Reviewers

- 컴포넌트에서 자체적으로 설정하는 margin, padding 과 중복돼서 적용되지 않는지 확인하고 PR 올리기

## 📸 스크린샷

<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->

<img width="693" alt="image" src="https://github.com/PICK-PLE/PICKPLE-client/assets/59465914/6c7576b2-b431-4a88-8117-a0f8b97bcc8d">

이렇게 로고헤더와 프로그레스바 그냥 예시로 넣어둠.

예시) 

https://github.com/PICK-PLE/PICKPLE-client/assets/59465914/c9bfdd6b-899c-4f4e-aa44-0e8ca0be5029

디바이스크기를 375에서 쭉 늘려보면 화면에 꽉맞게 늘어나는 걸 볼 수 있음. width 100%로 설정해줘서 그럼. 이렇게 잘 늘어나는지 확인하고 PR올리기.
디바이스크기 375px 보다 작은 부분은 안봐도 됨. 잘리는게 정상.