### PR TITLE
feat: SimpleUserProfile 컴포넌트 size별로 스타일 수정

### DIFF
--- a/src/components/common/SimpleUserProfile/SimpleUserProfile.style.ts
+++ b/src/components/common/SimpleUserProfile/SimpleUserProfile.style.ts
@@ -6,6 +6,17 @@ export const profileWrapperStyle = css`
   gap: 1rem;
   width: 13rem;
 `;
+export const profileWrapperSizeStyle = {
+  large: css`
+    gap: 1rem;
+  `,
+  medium: css`
+    gap: 1rem;
+  `,
+  small: css`
+    gap: 0.5rem;
+  `,
+};
 
 export const imgStyle = css`
   width: 4.2rem;
@@ -15,7 +26,33 @@ export const imgStyle = css`
   object-fit: cover;
 `;
 
+export const imgSizeStyle = {
+  large: css`
+    width: 4.2rem;
+    height: 4.2rem;
+  `,
+  medium: css`
+    width: 2.5rem;
+    height: 2.5rem;
+  `,
+  small: css`
+    width: 1.8rem;
+    height: 1.8rem;
+  `,
+};
+
 export const usernameStyle = (theme: Theme) => css`
-  ${theme.font['subhead02-sb-16']}
-  color: ${theme.color.blackgray}
+  color: ${theme.color.blackgray};
 `;
+
+export const usernameSizeStyle = {
+  large: (theme: Theme) => css`
+    ${theme.font['subhead04-sb-15']}
+  `,
+  medium: (theme: Theme) => css`
+    ${theme.font['subhead05-sb-14']}
+  `,
+  small: (theme: Theme) => css`
+    ${theme.font['body04-m-12']}
+  `,
+};

--- a/src/components/common/SimpleUserProfile/SimpleUserProfile.tsx
+++ b/src/components/common/SimpleUserProfile/SimpleUserProfile.tsx
@@ -1,17 +1,29 @@
 import React from 'react';
-import { imgStyle, profileWrapperStyle, usernameStyle } from './SimpleUserProfile.style';
+import {
+  imgSizeStyle,
+  imgStyle,
+  profileWrapperSizeStyle,
+  profileWrapperStyle,
+  usernameSizeStyle,
+  usernameStyle,
+} from './SimpleUserProfile.style';
 
 export interface SimpleUserProfileProps extends React.HTMLAttributes<HTMLDivElement> {
+  size: 'small' | 'medium' | 'large';
   username: string;
   userImgUrl?: string;
 }
 
-const SimpleUserProfile = ({ userImgUrl, username }: SimpleUserProfileProps) => {
+const SimpleUserProfile = ({ size, userImgUrl, username }: SimpleUserProfileProps) => {
   const defaultImgUrl = 'svg/ic_default-userimg.svg';
   return (
-    <div css={profileWrapperStyle}>
-      <img src={userImgUrl || defaultImgUrl} alt={`${username}의 이미지`} css={imgStyle} />
-      <span css={usernameStyle}>{username}</span>
+    <div css={[profileWrapperStyle, profileWrapperSizeStyle[size]]}>
+      <img
+        src={userImgUrl || defaultImgUrl}
+        alt={`${username}의 이미지`}
+        css={[imgStyle, imgSizeStyle[size]]}
+      />
+      <span css={[usernameStyle, usernameSizeStyle[size]]}>{username}</span>
     </div>
   );
 };

--- a/src/pages/dev/Dev.tsx
+++ b/src/pages/dev/Dev.tsx
@@ -2,6 +2,7 @@ import { Carousel, ProgressBar } from '@components';
 import LogoHeader from 'src/components/common/headers/LogoHeader/LogoHeader';
 import { devContainer } from './Dev.style';
 import ApplicantAccordionList from 'src/components/common/applicantAccordions/ApplicantAccoridonList/ApplicantAccordionList';
+import SimpleUserProfile from 'src/components/common/SimpleUserProfile/SimpleUserProfile';
 
 const Dev = () => {
   const imageList = [
@@ -20,6 +21,9 @@ const Dev = () => {
         {/* 여기에 컴포넌트 추가해보고, 디바이스 크기 조정해보면서 테스트 */}
         <ApplicantAccordionList moimId={1} />
       </section>
+      <SimpleUserProfile size="large" username="신청자" />
+      <SimpleUserProfile size="medium" username="달아오르구마" />
+      <SimpleUserProfile size="small" username="달아아오르구마마마마" />
     </>
   );
 };


### PR DESCRIPTION
<!-- PR의 제목은 "[Feat/#1] 로그인 기능 추가" 와 같이 작성해주세요! -->

## 📌 관련 이슈번호

- Closes #83 
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

## ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 피그마 상에 SimpleUserProfile 컴포넌트가 size별로 다르게 구현되어 있어서 size prop을 추가했습니다.

## 📢 To Reviewers

-

## 📸 스크린샷
<img width="215" alt="스크린샷 2024-07-10 오후 6 22 52" src="https://github.com/PICK-PLE/PICKPLE-client/assets/101498590/e8f77cd0-1cb5-4491-8b00-4c5d80c9f886">

<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->
