### PR TITLE
[Feat/#150] 유저 로그인 정보 전역상태 저장

### DIFF
--- a/src/pages/home/page/Home/Home.tsx
+++ b/src/pages/home/page/Home/Home.tsx
@@ -11,7 +11,6 @@ import {
 } from './Home.style';
 import { CATEGORY_ICON, CATEGORY_NAME } from 'src/constants/category';
 import Footer from 'src/components/common/Footer/Footer';
-import { useFetchMoimCategories } from '@apis/domains/moim/useFetchMoimCategories';
 
 const Home = () => {
   // CATEGORY_ICON 객체의 키와 값을 배열로 변환
@@ -19,10 +18,10 @@ const Home = () => {
     icon: icon.fill_selected,
     name: CATEGORY_NAME[key as keyof typeof CATEGORY_NAME],
   }));
-
-  const { data } = useFetchMoimCategories();
-
-  console.log('moim data', data);
+  // const [user] = useAtom(userAtom);
+  // const { data } = useFetchMoimCategories();
+  // console.log('user', user);
+  // console.log('moim data', data);
 
   return (
     <>

--- a/src/stores/user.ts
+++ b/src/stores/user.ts
@@ -1,13 +1,9 @@
-import { atom } from 'jotai';
 import { UserType } from '@types';
+import { atomWithStorage } from 'jotai/utils';
 
-export const userAtom = atom<UserType>({
-  guestNickname: 'asdfasdf',
+export const userAtom = atomWithStorage<UserType>('user', {
+  guestNickname: '',
   guestId: 0,
   hostNickname: '',
   hostId: 0,
-  token: {
-    accessToken: '',
-    refreshToken: '',
-  },
 });

--- a/src/types/commonType.ts
+++ b/src/types/commonType.ts
@@ -9,5 +9,4 @@ export interface UserType {
   guestId: number;
   hostNickname: string;
   hostId: number;
-  token: Token;
 }


### PR DESCRIPTION
<!-- PR의 제목은 "[Feat/#1] 로그인 기능 추가" 와 같이 작성해주세요! -->

## 📌 관련 이슈번호

- Closes #150
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

## ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 로그인 정보 전역상태 저장
   - 로그인하면 받아오는 유저데이터(guestid, guestNickname, hostId, hostNickname)을 전역상태에 저장
   - useAtom(userAtom)해서 그냥 가져오면됨

## 📢 To Reviewers

-

## 📸 스크린샷

<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->
