### PR TITLE
[Feat/#175] 유저 플로우 점검 (버튼 onClick 및 api 요청 테스트 & 타입 변환)

### DIFF
--- a/src/apis/domains/host/useFetchMoimHost.ts
+++ b/src/apis/domains/host/useFetchMoimHost.ts
@@ -1,7 +1,10 @@
 import { useQuery } from '@tanstack/react-query';
 import { QUERY_KEY } from '@apis/queryKeys/queryKeys';
 import { get } from '@apis/api';
-import { ApiResponseType, MoimHostResponseType } from '@types';
+import { ApiResponseType } from '@types';
+import { components } from '@schema';
+
+type MoimHostResponseType = components['schemas']['HostGetResponse'];
 
 const getMoimHost = async (hostId: number): Promise<MoimHostResponseType | null> => {
   try {

--- a/src/apis/domains/moim/useFetchGuestParticipate.ts
+++ b/src/apis/domains/moim/useFetchGuestParticipate.ts
@@ -1,19 +1,29 @@
 import { get } from '@apis/api';
 import { QUERY_KEY } from '@apis/queryKeys/queryKeys';
+import { components } from '@schema';
 import { useQuery } from '@tanstack/react-query';
+import { ApiResponseType } from '@types';
 
-const getGuestParticipateMoim = async (guestId: number) => {
-  const response = await get(`/guest/${guestId}/completed-moim-list`);
-
-  if (!response) {
+type SubmittedMoimByGuestResponse = components['schemas']['SubmittedMoimByGuestResponse'];
+const getGuestParticipateMoim = async (
+  guestId: number
+): Promise<SubmittedMoimByGuestResponse[] | null> => {
+  try {
+    const response = await get<ApiResponseType<SubmittedMoimByGuestResponse[]>>(
+      `/guest/${guestId}/completed-moim-list`
+    );
+    console.log('response.data.data', response.data.data);
+    return response.data.data;
+  } catch (err) {
+    console.error(err);
     return null;
   }
-  return response;
 };
 
-export const useFetchGuestParticipate = (questId: number) => {
+export const useFetchGuestParticipate = (guestId: number) => {
   return useQuery({
     queryKey: [QUERY_KEY.GUEST_PARTICIPATE],
-    queryFn: () => getGuestParticipateMoim(questId),
+    queryFn: () => getGuestParticipateMoim(guestId),
+    enabled: !!guestId && guestId > 0,
   });
 };

--- a/src/apis/domains/moim/useFetchHostMoimInfo.ts
+++ b/src/apis/domains/moim/useFetchHostMoimInfo.ts
@@ -1,7 +1,7 @@
 import { get } from '@apis/api';
 import { QUERY_KEY } from '@apis/queryKeys/queryKeys';
-import { useQuery } from '@tanstack/react-query';
-import { HostMyClassDataResponseType } from '@types';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
+import { ApiResponseType, HostMyClassDataResponseType } from '@types';
 
 interface GetHostMoimInfoResponse {
   data: HostMyClassDataResponseType[];
@@ -10,16 +10,18 @@ interface GetHostMoimInfoResponse {
 const getHostMoimInfo = async (
   hostId: number,
   moimState: string
-): Promise<GetHostMoimInfoResponse | null> => {
+): Promise<GetHostMoimInfoResponse[] | null> => {
   try {
-    const response = await get<GetHostMoimInfoResponse>(
+    const response = await get<ApiResponseType<GetHostMoimInfoResponse[]>>(
       `/host/${hostId}/moim-list?moimState=${moimState}`
     );
 
     if (!response) {
       return null;
     }
-    return response.data;
+
+    console.log('response.data.data', response.data.data);
+    return response.data.data;
   } catch (err) {
     console.error(err);
     return null;
@@ -28,8 +30,9 @@ const getHostMoimInfo = async (
 
 export const useFetchHostMoimInfo = (hostId: number, moimState: string) => {
   return useQuery({
-    //쿼리 키가 여러개로 구성되어 있을 때, 하나만 달라져도 새롭게 캐싱해옴.
     queryKey: [QUERY_KEY.HOST_MOIM_INFO, hostId, moimState],
     queryFn: () => getHostMoimInfo(hostId, moimState),
+    enabled: !!hostId && hostId !== 0,
+    placeholderData: keepPreviousData,
   });
 };

--- a/src/components/common/ImageSelect/ImageSelect.tsx
+++ b/src/components/common/ImageSelect/ImageSelect.tsx
@@ -1,4 +1,4 @@
-import { InputHTMLAttributes, useState } from 'react';
+import { InputHTMLAttributes, useRef, useState } from 'react';
 import {
   imageSelectWrapper,
   inputStyle,
@@ -18,7 +18,8 @@ interface ImageSelectProps extends InputHTMLAttributes<HTMLInputElement> {
 
 const ImageSelect = ({ onFileSelect, isMultiple = false }: ImageSelectProps) => {
   const [previewURLs, setPreviewURLs] = useState<string[]>([]);
-  const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
+
+  const inputRef = useRef<HTMLInputElement>(null);
 
   const readFile = (file: File): Promise<string> => {
     return new Promise((resolve, reject) => {
@@ -58,17 +59,15 @@ const ImageSelect = ({ onFileSelect, isMultiple = false }: ImageSelectProps) => 
       ) as string[];
 
       setPreviewURLs((prev) => [...prev, ...newPreviewURLs]);
-      setSelectedFiles((prev) => [...prev, ...allowedFiles]);
-      onFileSelect([...selectedFiles, ...allowedFiles]); // 선택된 파일 목록을 부모 컴포넌트에 전달
+      onFileSelect([...allowedFiles]); // 선택된 파일 목록을 부모 컴포넌트에 전달
     }
   };
 
   const handleDeleteImage = (index: number) => {
-    const updatedPreviewURLs = previewURLs.filter((_, i) => i !== index);
-    const updatedFiles = selectedFiles.filter((_, i) => i !== index);
-    setPreviewURLs(updatedPreviewURLs);
-    setSelectedFiles(updatedFiles);
-    onFileSelect(updatedFiles); // 업데이트된 파일 목록을 부모 컴포넌트에 전달
+    setPreviewURLs(previewURLs.filter((_, i) => i !== index));
+    if (inputRef.current) {
+      inputRef.current.value = '';
+    }
   };
 
   return (
@@ -81,6 +80,7 @@ const ImageSelect = ({ onFileSelect, isMultiple = false }: ImageSelectProps) => 
         </div>
       </label>
       <input
+        ref={inputRef}
         type="file"
         multiple={isMultiple}
         accept="image/jpeg, image/png, image/jpg, image/webp"

--- a/src/pages/class/page/ClassNotice/ClassNotice.tsx
+++ b/src/pages/class/page/ClassNotice/ClassNotice.tsx
@@ -9,6 +9,7 @@ import { useState, useEffect } from 'react';
 import { usePutS3Upload } from '@apis/domains/presignedUrl/usePutS3Upload';
 import { usePostNotice } from '@apis/domains/notice';
 import { handleUpload } from 'src/utils/image';
+import { useNavigate } from 'react-router-dom';
 
 const ClassNotice = () => {
   const [noticeTitle, setNoticeTitle] = useState('');
@@ -17,6 +18,12 @@ const ClassNotice = () => {
   const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
   const putS3UploadMutation = usePutS3Upload();
   const postNoticeMutation = usePostNotice();
+
+  const navigate = useNavigate();
+
+  const handleNavigateToMoimInfo = (moimId: number) => {
+    navigate(`/class/${moimId}`);
+  };
 
   const handleTitleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setNoticeTitle(e.target.value);
@@ -35,20 +42,25 @@ const ClassNotice = () => {
   };
 
   const handleButtonClick = async (): Promise<void> => {
-    const imageUrlList = await handleUpload({
-      selectedFiles,
-      putS3Upload: putS3UploadMutation.mutateAsync,
-      type: 'notice',
-    });
-
+    let imageUrl: undefined | string = undefined;
+    console.log('selectedFiles.length', selectedFiles.length);
+    if (selectedFiles.length === 1) {
+      const imageUrlList = await handleUpload({
+        selectedFiles,
+        putS3Upload: putS3UploadMutation.mutateAsync,
+        type: 'notice',
+      });
+      imageUrl = imageUrlList[0];
+    }
     const params = {
       noticeTitle,
       noticeContent,
-      imageUrl: imageUrlList[0],
+      imageUrl,
     };
 
-    const moimId = 1; //정안TODO 실제 모임ID로 변경
+    const moimId = 5; //정안TODO 실제 모임ID로 변경
     await postNoticeMutation.mutateAsync({ params, moimId });
+    handleNavigateToMoimInfo(moimId);
   };
 
   return (
@@ -77,10 +89,7 @@ const ClassNotice = () => {
           </div>
         </main>
 
-        <Button
-          variant="large"
-          disabled={isButtonDisabled || selectedFiles.length === 0}
-          onClick={() => handleButtonClick()}>
+        <Button variant="large" disabled={isButtonDisabled} onClick={() => handleButtonClick()}>
           게시하기
         </Button>
       </div>

--- a/src/pages/guest/components/MoimCard/MoimCard.tsx
+++ b/src/pages/guest/components/MoimCard/MoimCard.tsx
@@ -1,4 +1,4 @@
-import { Button, Image, Label } from '@components';
+import { Button, Image, Label, Modal } from '@components';
 import {
   detailWrapper,
   detailInfoWrapper,
@@ -14,13 +14,27 @@ import {
 import { IcDropdownRight } from '@svg';
 import { MoimResponseType } from '@types';
 import { statusMapText } from 'src/constants/mappingText';
+import { useState } from 'react';
+import DepositModal from '../DepositModal/DepositModal';
+import { useNavigate } from 'react-router-dom';
 
 interface MoimCardProps {
   guestMyClassData: MoimResponseType;
 }
 
 const MoimCard = ({ guestMyClassData }: MoimCardProps) => {
-  const { moimSubmissionState, title, hostNickname, dateList, fee, imageUrl } = guestMyClassData;
+  const { moimSubmissionState, title, hostNickname, dateList, fee, imageUrl, moimId } =
+    guestMyClassData;
+  const navigate = useNavigate();
+  const [isOpen, setIsOpen] = useState(false);
+  const handleButtonClick = () => {
+    setIsOpen(!isOpen);
+  };
+
+  const handleCardClick = () => {
+    navigate(`/class/${moimId}`);
+  };
+
   return (
     <div css={moimCardLayout}>
       <article css={moimCardContainer}>
@@ -34,7 +48,7 @@ const MoimCard = ({ guestMyClassData }: MoimCardProps) => {
           }
         />
         <article css={detailInfoWrapper}>
-          <div css={titleWrapper} onClick={() => {}}>
+          <div css={titleWrapper} onClick={handleCardClick}>
             <p css={titleStyle}>{title}</p>
             <IcDropdownRight css={iconStyle} />
           </div>
@@ -57,10 +71,15 @@ const MoimCard = ({ guestMyClassData }: MoimCardProps) => {
         </article>
       </article>
       {moimSubmissionState === 'pendingPayment' ? (
-        <Button variant="xSmall" onClick={() => {}}>
+        <Button variant="xSmall" onClick={handleButtonClick}>
           입금하기
         </Button>
       ) : null}
+      {isOpen && (
+        <Modal onClose={handleButtonClick}>
+          <DepositModal onClose={handleButtonClick} />
+        </Modal>
+      )}
     </div>
   );
 };

--- a/src/pages/host/components/HostMyClassCard/HostMyClassCard.tsx
+++ b/src/pages/host/components/HostMyClassCard/HostMyClassCard.tsx
@@ -9,26 +9,40 @@ import {
   cardTitleWrapper,
 } from './HostMyClassCard.style';
 import { HostMyClassDataResponseType } from '@types';
+import { useNavigate } from 'react-router-dom';
+import { routePath } from '@constants';
 
 interface HostMyClassCardProps {
   hostMyClassData: HostMyClassDataResponseType;
 }
-
 const HostMyClassCard = ({ hostMyClassData }: HostMyClassCardProps) => {
-  const { moimImage, title, approvedGuest, maxGuest } = hostMyClassData;
+  const { moimImage, title, approvedGuest, maxGuest, moimId } = hostMyClassData;
+
+  const navigate = useNavigate();
+
+  const handleButtonClick = () => {
+    navigate(routePath.HOST_MY_CLASS_MANAGE);
+  };
+
+  const handleCardClick = () => {
+    navigate(`/class/${moimId}`);
+  };
+
   return (
     <article css={cardContainer}>
       <section css={cardContent}>
         <Image src={moimImage} width="8.2rem" />
         <div css={cardText}>
-          <div css={cardTitleWrapper} onClick={() => {}}>
+          <div css={cardTitleWrapper} onClick={handleCardClick}>
             <h3 css={cardTitle}>{title} </h3>
             <IcDropdownRight css={cardIcon} />
           </div>
           <Label variant="textCount">{`승인 현황 ${approvedGuest} / ${maxGuest}`}</Label>
         </div>
       </section>
-      <Button variant="stroke">신청자 관리</Button>
+      <Button variant="stroke" onClick={handleButtonClick}>
+        신청자 관리
+      </Button>
     </article>
   );
 };

--- a/src/pages/host/page/HostMyClass/HostMyClass.tsx
+++ b/src/pages/host/page/HostMyClass/HostMyClass.tsx
@@ -6,16 +6,25 @@ import {
   tabWrapper,
   tapLine,
 } from './HostMyClass.style';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { HostMyClassEmptyView } from '@pages/host/components';
 import { hostMyClassCardData } from 'src/constants/mocks/HostMyClassCardData';
 import { HostMyClassCard } from '@pages/host/components';
 
 import { Header } from '@components';
 import { useFetchHostMoimInfo } from '@apis/domains/moim/useFetchHostMoimInfo';
+import { useAtom } from 'jotai';
+import { userAtom } from '@stores';
 const HostMyClass = () => {
   const [activeTab, setActiveTab] = useState<'진행 중' | '완료'>('진행 중');
   const [moimState, setMoimState] = useState<'ongoing' | 'completed'>('ongoing');
+
+  const [{ hostId }] = useAtom(userAtom);
+
+  /**@정안TODO 현재 서버에서 모임을 전부 제거한 이슈로 useEffect 없어도 되는지 테스트 불가 */
+  useEffect(() => {
+    setMoimState(!activeTab ? 'ongoing' : 'completed');
+  }, [moimState, activeTab, hostId]);
 
   const handleOngoingTabClick = () => {
     setActiveTab('진행 중');
@@ -27,9 +36,10 @@ const HostMyClass = () => {
     setMoimState('completed');
   };
 
-  /**@정안TODO 현재 서버에서 hostId는 1로만 구현하랍니다 */
-  const hostId = 1;
-  const { data } = useFetchHostMoimInfo(hostId, moimState);
+  /**@정안TODO 장정안의 hostId는 5
+   * 현재 hostId가 0찍혔다가 null로 오는 이슈가 있음.
+   */
+  const { data } = useFetchHostMoimInfo(5, moimState || 'ongoing');
 
   if (!data) {
     return <div>no data</div>;
@@ -53,7 +63,7 @@ const HostMyClass = () => {
           <HostMyClassEmptyView text="아직 진행 중인 모임이 없어요" />
         ) : (
           <div css={hostMyClassCardContainer}>
-            {data.data.map((data) => (
+            {data.map((data) => (
               <HostMyClassCard key={data.moimId} hostMyClassData={data} />
             ))}
           </div>

--- a/src/pages/myPage/components/HostInfoCardWithLink/HostInfoCardWithLink.tsx
+++ b/src/pages/myPage/components/HostInfoCardWithLink/HostInfoCardWithLink.tsx
@@ -13,14 +13,20 @@ import { Button, Image, InterestCategoryButton } from '@components';
 import { CATEGORY_NAME, CATEGORY_SMALL_ICON } from 'src/constants/category';
 import HostMyPageEmptyView from '../HostMyPageEmptyView/HostMyPageEmptyView';
 import { HostCategoryList, HostInfoCardWithLinkDataResponseType } from '@types';
+import { useNavigate } from 'react-router-dom';
+import { routePath } from '@constants';
 
 interface hostInfoCardWithLinkListProps {
   hostInfoCardWithLinkList: HostInfoCardWithLinkDataResponseType;
 }
 const HostInfoCardWithLink = ({ hostInfoCardWithLinkList }: hostInfoCardWithLinkListProps) => {
   const { hostNickName, hostLink, hostCategoryList, hostImageUrl } = hostInfoCardWithLinkList;
-
+  const navigate = useNavigate();
   const categoryKeys: (keyof HostCategoryList)[] = ['category1', 'category2', 'category3'];
+
+  const handleButtonClick = () => {
+    navigate(routePath.CLASS_POST);
+  };
 
   return (
     <section css={hostInfoCardWithLinkLayout}>
@@ -52,7 +58,9 @@ const HostInfoCardWithLink = ({ hostInfoCardWithLinkList }: hostInfoCardWithLink
                   );
                 })}
               </article>
-              <Button variant="small">클래스 모임 개설하기</Button>
+              <Button variant="small" onClick={handleButtonClick}>
+                클래스 모임 개설하기
+              </Button>
             </section>
           </div>
         </>


### PR DESCRIPTION
<!-- PR의 제목은 "[Feat/#1] 로그인 기능 추가" 와 같이 작성해주세요! -->

## 📌 관련 이슈번호

- Closes #175 
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

## ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 내용
   - api 연결 후 버튼에 onClick 등 navigate 해놓지 않은 부분 자연스럽게 연결하였습니다.
   - Modal 로직도 연결 완료하였습니다.
   - ref 이용해서 미리보기 이미지 삭제 후 같은 이미지 업로드 시 화면에 출력되지 않는 현상 수정했습니다.
   따라서 ImageSelect 컴포넌트 변동있습니다. @thisishwarang 머지 후 체크 부탁드려요.
  

## 📢 To Reviewers

- 상위 컴포넌트 타입에서 props로 내려준 data type과 하위 컴포넌트 타입이 계속해서 일치하지 않는 문제가 있습니다.
- undefined 타입이 계속해서 말썽인데, 여러군데 조언 얻어서 꼭 공유하겠습니다.
- openapi typescript에서 지정해준 타입으로 바꿨는데 혹시 안된 부분 있다면 리뷰 남겨주시면 바로 처리하겠습니다.

## 📸 스크린샷

<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->
