### PR TITLE
[Fix/#204] web파트 자체 qa

### DIFF
--- a/src/apis/domains/moimSubmission/usePostAnswerList.ts
+++ b/src/apis/domains/moimSubmission/usePostAnswerList.ts
@@ -2,17 +2,21 @@ import { post } from '@apis/api';
 import { QUERY_KEY } from '@apis/queryKeys/queryKeys';
 import { DataType } from '@pages/class/page/ClassApply/ClassApplyQuestion/ClassApplyQuestion';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { ErrorResponse } from '@types';
+import { ErrorResponse, ErrorType, MutateResponseType } from '@types';
+import { useNavigate } from 'react-router-dom';
 
 interface PostAnswerRequest {
   moimId: number;
   body: DataType;
 }
 
-const postAnswerList = async ({ moimId, body }: PostAnswerRequest) => {
+const postAnswerList = async ({
+  moimId,
+  body,
+}: PostAnswerRequest): Promise<MutateResponseType | ErrorType> => {
   try {
-    const response = await post(`/moim/${moimId}`, body);
-    return response;
+    const response = await post<MutateResponseType>(`/moim/${moimId}`, body);
+    return response.data;
   } catch (error) {
     const err = error as ErrorResponse;
     if (err.response) {
@@ -27,6 +31,11 @@ const postAnswerList = async ({ moimId, body }: PostAnswerRequest) => {
         errorMessage = '존재하지 않는 모임입니다.';
       }
 
+      return {
+        status: statusCode,
+        message: errorMessage,
+      };
+
       throw new Error(errorMessage);
     } else {
       throw new Error('unknown error');
@@ -34,12 +43,19 @@ const postAnswerList = async ({ moimId, body }: PostAnswerRequest) => {
   }
 };
 
-export const usePostAnswerList = () => {
+export const usePostAnswerList = (moimId: string) => {
+  const navigate = useNavigate();
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: ({ moimId, body }: PostAnswerRequest) => postAnswerList({ moimId, body }),
-    onSuccess: () => {
+    onSuccess: (data) => {
       queryClient.invalidateQueries({ queryKey: [QUERY_KEY.ANSWER_LIST] });
+      if (data.status === 20008) {
+        navigate(`/class/${moimId}/apply/deposit`);
+      } else {
+        alert(data.message);
+        navigate(-2);
+      }
     },
   });
 };

--- a/src/components/common/buttons/PayButton/PayButton.style.ts
+++ b/src/components/common/buttons/PayButton/PayButton.style.ts
@@ -17,4 +17,5 @@ export const payButtonStyle = (theme: Theme) => css`
 
 export const paySpanStyle = (theme: Theme) => css`
   ${theme.font['body02-r-14']};
+  color: ${theme.color.blackgray};
 `;

--- a/src/components/common/buttons/ShareButton/ShareButton.tsx
+++ b/src/components/common/buttons/ShareButton/ShareButton.tsx
@@ -9,21 +9,9 @@ export interface ShareButtonProps extends ButtonHTMLAttributes<HTMLButtonElement
 }
 
 // TODO: https 환경에서 테스트. 별로라면 공유하기 기능 모달로 변경
-const ShareButton = ({
-  url = 'https://pick-ple.com',
-  title = 'PICK!PLE',
-  text = "내가 PICK!한 바로 '그 사람'과 함께하는 클래스 모임.",
-}: ShareButtonProps) => {
+const ShareButton = ({ onClick }: ShareButtonProps) => {
   return (
-    <button
-      css={buttonStyle}
-      onClick={() => {
-        navigator.share({
-          url,
-          title,
-          text,
-        });
-      }}>
+    <button css={buttonStyle} onClick={onClick}>
       <IcShare css={iconStyle} />
     </button>
   );

--- a/src/pages/class/components/GuestClassRegisterCard/GuestClassRegisterCard.tsx
+++ b/src/pages/class/components/GuestClassRegisterCard/GuestClassRegisterCard.tsx
@@ -23,12 +23,12 @@ import { MoimIdPathParameterType } from '@types';
 const GuestClassRegisterCard = ({ moimId }: MoimIdPathParameterType) => {
   const { data: appliedMoimData, isLoading } = useFetchSubmittedMoimDetail(Number(moimId));
 
-  if (!appliedMoimData) {
-    return <Error />;
-  }
-
   if (isLoading) {
     return <Spinner />;
+  }
+
+  if (!appliedMoimData) {
+    return <Error />;
   }
 
   const { title, hostNickname, isOffline, spot, dateList, fee, hostImageUrl, moimImageUrl } =

--- a/src/pages/class/components/StepFour/StepFour.tsx
+++ b/src/pages/class/components/StepFour/StepFour.tsx
@@ -10,8 +10,16 @@ import {
   titleStyle,
 } from './StepFour.style';
 import { HostClassOpenImage } from '@image';
+import { useNavigate } from 'react-router-dom';
+import { routePath } from '@constants';
 
 const StepFour = () => {
+  const navigate = useNavigate();
+
+  const handleButtonClick = () => {
+    navigate(routePath.CATEGORY);
+  };
+
   return (
     <>
       <ProgressBar progress={100} />
@@ -29,7 +37,9 @@ const StepFour = () => {
           <img src={HostClassOpenImage} css={imageStyle} />
         </main>
         <footer css={footerStyle}>
-          <Button variant="large">개설한 모임 보러가기</Button>
+          <Button variant="large" onClick={handleButtonClick}>
+            개설한 모임 보러가기
+          </Button>
         </footer>
       </div>
     </>

--- a/src/pages/class/page/Class/Class.tsx
+++ b/src/pages/class/page/Class/Class.tsx
@@ -55,6 +55,10 @@ const Class = () => {
     selectTab
   );
 
+  if (isMoimDetailLoading || isMoimDescriptionLoading) {
+    return <Spinner />;
+  }
+
   if (!moimDetail || !moimDescription) {
     return <Error />;
   }
@@ -69,10 +73,6 @@ const Class = () => {
   const handleApplyButtonClick = () => {
     navigate(`/class/${moimId}/apply/rule`);
   };
-
-  if (isMoimDetailLoading || isMoimDescriptionLoading) {
-    return <Spinner />;
-  }
 
   return (
     <div>

--- a/src/pages/class/page/Class/Class.tsx
+++ b/src/pages/class/page/Class/Class.tsx
@@ -15,6 +15,7 @@ import {
   LogoHeader,
   ShareButton,
   Spinner,
+  Toast,
 } from '@components';
 import {
   buttonContainer,
@@ -34,17 +35,19 @@ import { IcClassPerson, IcCopyPlus, IcDate, IcMoney, IcOffline, IcOneline } from
 
 import { useNavigate, useParams } from 'react-router-dom';
 import { useFetchMoimDetail, useFetchMoimDescription } from '@apis/domains/moim';
-import { useWindowSize } from '@hooks';
+import { useClipboard, useToast, useWindowSize } from '@hooks';
 import { useFetchMoimNoticeList } from '@apis/domains/notice';
 import { MoimIdPathParameterType } from '@types';
 import Error from '@pages/error/Error';
-import { dDayText } from '@utils';
+import { dDayText, handleShare } from '@utils';
 
 const Class = () => {
   const { windowWidth } = useWindowSize();
   const navigate = useNavigate();
   const [selectTab, setSelectTab] = useState<'모임소개' | '공지사항' | '리뷰'>('모임소개');
   const { moimId } = useParams<MoimIdPathParameterType>();
+  const { handleCopyToClipboard } = useClipboard();
+  const { showToast, isToastVisible } = useToast();
 
   const { data: moimDetail, isLoading: isMoimDetailLoading } = useFetchMoimDetail(moimId ?? '');
   const { data: moimDescription, isLoading: isMoimDescriptionLoading } = useFetchMoimDescription(
@@ -66,12 +69,21 @@ const Class = () => {
 
   const { date, dayOfWeek, startTime, endTime } = dateList ?? {};
 
+  const url = `https://pick-ple.com/class/${moimId}`;
+  const shareTitle = 'PICK!PLE';
+  const text = title ?? '';
+
   const handleNoticePostClick = (moimId: string) => {
     navigate(`/class/${moimId}/notice/post`);
   };
 
   const handleApplyButtonClick = () => {
     navigate(`/class/${moimId}/apply/rule`);
+  };
+
+  const handleShareButtonClick = () => {
+    handleShare(url, shareTitle, text, handleCopyToClipboard);
+    showToast();
   };
 
   return (
@@ -145,12 +157,17 @@ const Class = () => {
           </div>
         )}
         <section css={buttonContainer(windowWidth)}>
-          <ShareButton />
-          <Button variant="large" onClick={handleApplyButtonClick}>
+          <ShareButton onClick={handleShareButtonClick} />
+          <Button variant="large" onClick={handleApplyButtonClick} disabled={dayOfDay < 0}>
             참여하기
           </Button>
         </section>
       </div>
+      {isToastVisible && (
+        <Toast isVisible={isToastVisible} toastBottom={10}>
+          클립보드에 모임 링크를 복사했어요!
+        </Toast>
+      )}
     </div>
   );
 };

--- a/src/pages/class/page/ClassApply/ClassApplyQuestion/ClassApplyQuestion.tsx
+++ b/src/pages/class/page/ClassApply/ClassApplyQuestion/ClassApplyQuestion.tsx
@@ -113,12 +113,12 @@ const ClassApplyQuestion = () => {
     navigate(`/class/${moimId}/apply/deposit`);
   };
 
-  if (!questionData) {
-    return <Error />;
-  }
-
   if (isLoading) {
     return <Spinner />;
+  }
+
+  if (!questionData) {
+    return <Error />;
   }
 
   return (

--- a/src/pages/class/page/ClassApply/ClassApplyQuestion/ClassApplyQuestion.tsx
+++ b/src/pages/class/page/ClassApply/ClassApplyQuestion/ClassApplyQuestion.tsx
@@ -23,7 +23,7 @@ import {
 } from '@pages/class/page/ClassApply/ClassApplyQuestion/ClassApplyQuestion.style';
 import { IcCaution } from '@svg';
 import { useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import { useFetchQuestionList } from '@apis/domains/moim/useFetchQuestionList';
 import { usePostAnswerList } from '@apis/domains/moimSubmission/usePostAnswerList';
 import { MoimIdPathParameterType } from '@types';
@@ -43,8 +43,6 @@ export interface DataType {
 }
 
 const ClassApplyQuestion = () => {
-  const navigate = useNavigate();
-
   const { moimId } = useParams<MoimIdPathParameterType>();
 
   const [questionList, setQuestionList] = useState<string[]>([]);
@@ -62,7 +60,7 @@ const ClassApplyQuestion = () => {
     },
   });
 
-  const { mutate } = usePostAnswerList();
+  const { mutate } = usePostAnswerList(moimId ?? '');
 
   useEffect(() => {
     if (isSuccess && questionData) {
@@ -110,7 +108,6 @@ const ClassApplyQuestion = () => {
 
   const handleButtonClick = () => {
     mutate(requestData);
-    navigate(`/class/${moimId}/apply/deposit`);
   };
 
   if (isLoading) {

--- a/src/pages/guest/components/GuestMyClassEmptyView/GuestMyClassEmptyView.style.ts
+++ b/src/pages/guest/components/GuestMyClassEmptyView/GuestMyClassEmptyView.style.ts
@@ -3,7 +3,9 @@ import { flexGenerator } from '@styles/generator';
 
 export const completedTabContainer = (theme: Theme) => css`
   ${flexGenerator('column')}
-  padding-top: 9.6rem;
+  height: calc(100dvh - 15rem);
+  padding: 20% 9.3rem 0;
+  width: 100%;
 
   background-color: ${theme.color.background};
 `;

--- a/src/pages/guest/components/GuestMyClassEmptyView/GuestMyClassEmptyView.style.ts
+++ b/src/pages/guest/components/GuestMyClassEmptyView/GuestMyClassEmptyView.style.ts
@@ -4,7 +4,7 @@ import { flexGenerator } from '@styles/generator';
 export const completedTabContainer = (theme: Theme) => css`
   ${flexGenerator('column')}
   height: calc(100dvh - 15rem);
-  padding: 20% 9.3rem 0;
+  padding: 0 9.3rem;
   width: 100%;
 
   background-color: ${theme.color.background};

--- a/src/pages/guest/components/MoimCard/MoimCard.style.ts
+++ b/src/pages/guest/components/MoimCard/MoimCard.style.ts
@@ -67,3 +67,7 @@ export const detailInfoStyle = (theme: Theme) => css`
   color: ${theme.color.darkgray};
   ${theme.font['body04-m-12']};
 `;
+
+export const imageCustomStyle = css`
+  object-position: right;
+`;

--- a/src/pages/guest/components/MoimCard/MoimCard.tsx
+++ b/src/pages/guest/components/MoimCard/MoimCard.tsx
@@ -10,6 +10,7 @@ import {
   detailTitleStyle,
   detailInfoStyle,
   moimCardLayout,
+  imageCustomStyle,
 } from './MoimCard.style';
 import { IcDropdownRight } from '@svg';
 import { statusMapText } from 'src/constants/mappingText';
@@ -48,6 +49,7 @@ const MoimCard = ({ guestMyClassData }: MoimCardProps) => {
               <Label variant="status">{statusMapText[moimSubmissionState ?? '']}</Label>
             ) : null
           }
+          customStyle={imageCustomStyle}
         />
         <article css={detailInfoWrapper}>
           <div css={titleWrapper} onClick={handleCardClick}>

--- a/src/pages/guest/page/GuestMyClass/GuestMyClass.tsx
+++ b/src/pages/guest/page/GuestMyClass/GuestMyClass.tsx
@@ -48,12 +48,12 @@ const GuestMyClass = () => {
     setSelectedStatus(status);
   };
 
-  if (!applyData) {
-    return <Error />;
-  }
-
   if (isApplyLoading || isParticipateLoading) {
     return <Spinner />;
+  }
+
+  if (!applyData) {
+    return <Error />;
   }
 
   if (applyError || participateError) {

--- a/src/pages/guest/page/GuestMyClass/GuestMyClass.tsx
+++ b/src/pages/guest/page/GuestMyClass/GuestMyClass.tsx
@@ -91,14 +91,14 @@ const GuestMyClass = () => {
             </article>
           )}
 
-          {!currentData ? (
+          {currentData?.length === 0 ? (
             <GuestMyClassEmptyView
               text={
                 activeTab === '신청한' ? '아직 신청한 모임이 없어요' : '아직 참가한 모임이 없어요'
               }
             />
           ) : (
-            currentData.map((data) => (
+            currentData?.map((data) => (
               <div css={guestMyClassCardContainer} key={data.moimId}>
                 <MoimCard guestMyClassData={data} />
               </div>

--- a/src/pages/guest/page/GuestMyClass/GuestMyClass.tsx
+++ b/src/pages/guest/page/GuestMyClass/GuestMyClass.tsx
@@ -16,7 +16,6 @@ import { useAtom } from 'jotai';
 import { userAtom } from '@stores';
 import { statusMapText } from 'src/constants/mappingText';
 import { useFetchGuestApply, useFetchGuestParticipate } from '@apis/domains/moim';
-import Error from '@pages/error/Error';
 
 const GuestMyClass = () => {
   const [activeTab, setActiveTab] = useState<'신청한' | '참가한'>('신청한');
@@ -50,10 +49,6 @@ const GuestMyClass = () => {
 
   if (isApplyLoading || isParticipateLoading) {
     return <Spinner />;
-  }
-
-  if (!applyData) {
-    return <Error />;
   }
 
   if (applyError || participateError) {

--- a/src/pages/host/components/ClassManageEmptyView/ClassManageEmptyView.tsx
+++ b/src/pages/host/components/ClassManageEmptyView/ClassManageEmptyView.tsx
@@ -24,7 +24,6 @@ const ClassManageEmptyView = ({ moimId, maxGuest }: ClassManageEmptyViewProps) =
   const { handleCopyToClipboard } = useClipboard();
   const { showToast, isToastVisible } = useToast();
 
-  // 공유버튼 부분 예시
   const url = `https://pick-ple.com/class/${moimId}`;
   const title = 'PICK!PLE';
   const text = "내가 PICK!한 바로 '그 사람'과 함께하는 클래스 모임.";

--- a/src/pages/host/components/HostMyClassEmptyView/HostMyClassEmptyView.style.ts
+++ b/src/pages/host/components/HostMyClassEmptyView/HostMyClassEmptyView.style.ts
@@ -2,10 +2,10 @@ import { Theme, css } from '@emotion/react';
 import { flexGenerator } from '@styles/generator';
 
 export const completedTabContainer = (theme: Theme) => css`
-  ${flexGenerator('column')}
-  height: 100dvh;
-  padding: 9.5rem 9.9rem 20.9rem;
-
+  ${flexGenerator('column', 'flex-start', 'center')}
+  height: calc(100dvh - 10.4rem);
+  padding: 20% 9.3rem 0;
+  width: 100%;
   background-color: ${theme.color.background};
 `;
 
@@ -28,4 +28,9 @@ export const detailWrapper = css`
 export const IcHostMyClassStyle = css`
   width: 15rem;
   height: 15rem;
+`;
+
+export const buttonWrapper = css`
+  margin-top: 2rem;
+  width: 100%;
 `;

--- a/src/pages/host/components/HostMyClassEmptyView/HostMyClassEmptyView.tsx
+++ b/src/pages/host/components/HostMyClassEmptyView/HostMyClassEmptyView.tsx
@@ -1,10 +1,9 @@
 import { Button } from '@components';
 import {
+  buttonWrapper,
   completedTabContainer,
-  detailWrapper,
   IcHostMyClassStyle,
   textStyle,
-  textWrapper,
 } from './HostMyClassEmptyView.style';
 import { IcHostMypage } from '@svg';
 import { useNavigate } from 'react-router-dom';
@@ -22,11 +21,9 @@ const HostMyClassEmptyView = ({ text }: HostMyClassEmptyViewProps) => {
   return (
     <article css={completedTabContainer}>
       <IcHostMypage css={IcHostMyClassStyle} />
-      <div css={detailWrapper}>
-        <div css={textWrapper}>
-          <p css={textStyle}>{text}</p>
-          <p css={textStyle}>다양한 클래스 모임을 둘러보세요:{')'}</p>
-        </div>
+      <p css={textStyle}>{text}</p>
+      <p css={textStyle}>다양한 클래스 모임을 둘러보세요:{')'}</p>
+      <div css={buttonWrapper}>
         <Button variant="round" onClick={handleButtonClick}>
           클래스 모임 개설하기
         </Button>

--- a/src/pages/host/page/HostMyClass/HostMyClass.tsx
+++ b/src/pages/host/page/HostMyClass/HostMyClass.tsx
@@ -33,12 +33,12 @@ const HostMyClass = () => {
 
   const { data, isLoading } = useFetchHostMoimInfo(hostId ?? 0, moimState);
 
-  if (!data) {
-    return <Error />;
-  }
-
   if (isLoading) {
     return <Spinner />;
+  }
+
+  if (!data) {
+    return <Error />;
   }
 
   return (

--- a/src/pages/host/page/HostMyClass/HostMyClass.tsx
+++ b/src/pages/host/page/HostMyClass/HostMyClass.tsx
@@ -4,7 +4,6 @@ import {
   hostMyClassBackground,
   hostMyClassLayout,
   tabWrapper,
-  tapLine,
 } from './HostMyClass.style';
 import { useState } from 'react';
 import { HostMyClassEmptyView } from '@pages/host/components';
@@ -40,7 +39,6 @@ const HostMyClass = () => {
     <div css={hostMyClassBackground}>
       <Header title="my 클래스 모임" />
       <article css={hostMyClassLayout}>
-        <div css={tapLine} />
         <div css={tabWrapper}>
           <div css={getTabStyle(activeTab === '진행 중')} onClick={handleOngoingTabClick}>
             진행 중
@@ -50,7 +48,7 @@ const HostMyClass = () => {
           </div>
         </div>
 
-        {!data ? (
+        {data?.length === 0 ? (
           <HostMyClassEmptyView text="아직 진행 중인 모임이 없어요" />
         ) : (
           <div css={hostMyClassCardContainer}>

--- a/src/pages/host/page/HostMyClass/HostMyClass.tsx
+++ b/src/pages/host/page/HostMyClass/HostMyClass.tsx
@@ -14,7 +14,6 @@ import { Header, Spinner } from '@components';
 import { useFetchHostMoimInfo } from '@apis/domains/moim/useFetchHostMoimInfo';
 import { useAtom } from 'jotai';
 import { userAtom } from '@stores';
-import Error from '@pages/error/Error';
 const HostMyClass = () => {
   const [activeTab, setActiveTab] = useState<'진행 중' | '완료'>('진행 중');
   const [moimState, setMoimState] = useState<'ongoing' | 'completed'>('ongoing');
@@ -37,10 +36,6 @@ const HostMyClass = () => {
     return <Spinner />;
   }
 
-  if (!data) {
-    return <Error />;
-  }
-
   return (
     <div css={hostMyClassBackground}>
       <Header title="my 클래스 모임" />
@@ -55,11 +50,11 @@ const HostMyClass = () => {
           </div>
         </div>
 
-        {data.length === 0 ? (
+        {!data ? (
           <HostMyClassEmptyView text="아직 진행 중인 모임이 없어요" />
         ) : (
           <div css={hostMyClassCardContainer}>
-            {data.map((data) => (
+            {data?.map((data) => (
               <HostMyClassCard key={data.moimId} hostMyClassData={data} />
             ))}
           </div>

--- a/src/pages/myPage/components/HostMyPageEmptyView/HostMyPageEmptyView.style.ts
+++ b/src/pages/myPage/components/HostMyPageEmptyView/HostMyPageEmptyView.style.ts
@@ -4,8 +4,8 @@ import { flexGenerator } from '@styles/generator';
 export const hostMyPageEmptyViewContainer = css`
   height: calc(100dvh - 12.55rem);
   ${flexGenerator('column')};
+  width: 100%;
   gap: 2rem;
-  padding: 0 6.2rem;
 `;
 
 export const imageStyle = css`
@@ -24,4 +24,9 @@ export const textStyle = (theme: Theme) => css`
 
 export const textWrapper = css`
   ${flexGenerator()};
+`;
+
+export const buttonWrapper = css`
+  width: 100%;
+  padding: 0 9.3rem;
 `;

--- a/src/pages/myPage/components/HostMyPageEmptyView/HostMyPageEmptyView.tsx
+++ b/src/pages/myPage/components/HostMyPageEmptyView/HostMyPageEmptyView.tsx
@@ -7,6 +7,7 @@ import {
 } from './HostMyPageEmptyView.style';
 import { Button } from '@components';
 import { useNavigate } from 'react-router-dom';
+import { buttonWrapper } from '../LogoutModal/LogoutModal.style';
 
 const HostMyPageEmptyView = () => {
   const navigate = useNavigate();
@@ -21,9 +22,11 @@ const HostMyPageEmptyView = () => {
         <p css={textStyle}>아직 호스트로 등록되어 있지 않아요</p>
         <p css={textStyle}>호스트가 되어 다양한 게스트들을 만나 보세요!</p>
       </div>
-      <Button variant="round" onClick={handleButtonClick}>
-        호스트 신청하러 가기
-      </Button>
+      <div css={buttonWrapper}>
+        <Button variant="round" onClick={handleButtonClick}>
+          호스트 신청하러 가기
+        </Button>
+      </div>
     </div>
   );
 };

--- a/src/pages/myPage/components/HostMyPageEmptyView/HostMyPageEmptyView.tsx
+++ b/src/pages/myPage/components/HostMyPageEmptyView/HostMyPageEmptyView.tsx
@@ -1,5 +1,6 @@
 import { graphicImage } from '@constants';
 import {
+  buttonWrapper,
   hostMyPageEmptyViewContainer,
   hostMyPageEmptyViewWrapper,
   imageStyle,
@@ -7,7 +8,6 @@ import {
 } from './HostMyPageEmptyView.style';
 import { Button } from '@components';
 import { useNavigate } from 'react-router-dom';
-import { buttonWrapper } from '../LogoutModal/LogoutModal.style';
 
 const HostMyPageEmptyView = () => {
   const navigate = useNavigate();

--- a/src/pages/myPage/page/HostMyPage/HostMyPage.tsx
+++ b/src/pages/myPage/page/HostMyPage/HostMyPage.tsx
@@ -20,7 +20,6 @@ import { useAtom } from 'jotai';
 import { userAtom } from '@stores';
 import { useEffect, useState } from 'react';
 import LogoutModal from '@pages/myPage/components/LogoutModal/LogoutModal';
-import Error from '@pages/error/Error';
 
 const HostMyPage = () => {
   const [user, setUser] = useAtom(userAtom);
@@ -61,11 +60,6 @@ const HostMyPage = () => {
       }
     }
   }, [isSuccess, hostInfoData, setUser]);
-
-  /**@정안TODO Spinner보다 Error가 먼저 잡혀서 주석처리 해놓음 */
-  if (!hostInfoData) {
-    return <Error />;
-  }
 
   return (
     <>

--- a/src/pages/myPage/page/HostMyPage/HostMyPage.tsx
+++ b/src/pages/myPage/page/HostMyPage/HostMyPage.tsx
@@ -1,4 +1,4 @@
-import { LogoHeader, Modal, NavigateBox } from '@components';
+import { LogoHeader, Modal, NavigateBox, Spinner } from '@components';
 import {
   divdier,
   iconStyle,
@@ -23,7 +23,7 @@ import LogoutModal from '@pages/myPage/components/LogoutModal/LogoutModal';
 
 const HostMyPage = () => {
   const [user, setUser] = useAtom(userAtom);
-  const { data: hostInfoData, isSuccess } = useFetchMyHost();
+  const { data: hostInfoData, isSuccess, isLoading } = useFetchMyHost();
   const { goGuestMyPage } = useEasyNavigate();
   const [isModalOpen, setIsModalOpen] = useState(false);
 
@@ -61,6 +61,11 @@ const HostMyPage = () => {
     }
   }, [isSuccess, hostInfoData, setUser]);
 
+  /**@정안TODO Spinner보다 Error가 먼저 잡혀서 주석처리 해놓음 */
+  // if (!hostInfoData) {
+  //   return <Error />;
+  // }
+
   return (
     <>
       <LogoHeader isIcon={false} />
@@ -71,30 +76,36 @@ const HostMyPage = () => {
         <p css={[tabStyle, selectedTabStyle]}>호스트</p>
       </nav>
 
-      {hasHostInfoInJotai || hasHostInfoInResponse ? (
-        <main>
-          <div css={profileWrapper}>
-            <HostInfoCardWithLink hostInfoCardWithLinkList={hostInfoData ?? {}} />
-          </div>
-          <div css={divdier} />
-          <section css={navigateBoxContainer}>
-            <NavigateBox path={routePath.HOST_MY_CLASS}>my 클래스 모임</NavigateBox>
-            <div css={logoutBox} onClick={handleOpenKakaoClick}>
-              <span css={logoutTextStyle}>픽플에 문의하기</span>
-              <span css={iconStyle}>
-                <IcNext />
-              </span>
-            </div>
-            <div css={logoutBox} onClick={handleLogoutClick}>
-              <span css={logoutTextStyle}>로그아웃</span>
-              <span css={iconStyle}>
-                <IcNext />
-              </span>
-            </div>
-          </section>
-        </main>
+      {isLoading ? (
+        <Spinner variant="component" />
       ) : (
-        <HostMyPageEmptyView />
+        <>
+          {hasHostInfoInJotai || hasHostInfoInResponse ? (
+            <main>
+              <div css={profileWrapper}>
+                <HostInfoCardWithLink hostInfoCardWithLinkList={hostInfoData ?? {}} />
+              </div>
+              <div css={divdier} />
+              <section css={navigateBoxContainer}>
+                <NavigateBox path={routePath.HOST_MY_CLASS}>my 클래스 모임</NavigateBox>
+                <div css={logoutBox} onClick={handleOpenKakaoClick}>
+                  <span css={logoutTextStyle}>픽플에 문의하기</span>
+                  <span css={iconStyle}>
+                    <IcNext />
+                  </span>
+                </div>
+                <div css={logoutBox} onClick={handleLogoutClick}>
+                  <span css={logoutTextStyle}>로그아웃</span>
+                  <span css={iconStyle}>
+                    <IcNext />
+                  </span>
+                </div>
+              </section>
+            </main>
+          ) : (
+            <HostMyPageEmptyView />
+          )}
+        </>
       )}
 
       {isModalOpen && (

--- a/src/pages/myPage/page/HostMyPage/HostMyPage.tsx
+++ b/src/pages/myPage/page/HostMyPage/HostMyPage.tsx
@@ -20,6 +20,7 @@ import { useAtom } from 'jotai';
 import { userAtom } from '@stores';
 import { useEffect, useState } from 'react';
 import LogoutModal from '@pages/myPage/components/LogoutModal/LogoutModal';
+import Error from '@pages/error/Error';
 
 const HostMyPage = () => {
   const [user, setUser] = useAtom(userAtom);
@@ -62,9 +63,9 @@ const HostMyPage = () => {
   }, [isSuccess, hostInfoData, setUser]);
 
   /**@정안TODO Spinner보다 Error가 먼저 잡혀서 주석처리 해놓음 */
-  // if (!hostInfoData) {
-  //   return <Error />;
-  // }
+  if (!hostInfoData) {
+    return <Error />;
+  }
 
   return (
     <>


### PR DESCRIPTION
<!-- PR의 제목은 "[Feat/#1] 로그인 기능 추가" 와 같이 작성해주세요! -->

## 📌 관련 이슈번호

- Closes #204 
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

## ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 내용
   - 호스트 신청이 이미 대기중인데 다시 호스트 신청하면 400뜸. 유저한테 이미 대기중이라고 알려주고 navigate(-2)
   - 게스트 마이클래스에서 필터링된 모임이 없으면 에러뷰가 아니라 엠티뷰로
   - 호스트 마이페이지(승인전) flex풀고, padding-top: 20% 로 수정해야함
   - 게스트 마이클래스 엠티뷰 위치수정
   - 호스트신청 후 다른모임 둘러보기 버튼 클릭시 /categories 페이지로 라우팅
   - 호스트 마이페이지에서 호스트인데도 불구하고 진행중인 모임이 없다면 엠티뷰가 뜨게
   - 개설한 모임 보러가기 클릭 시 navigate
   - 모임 상세페이지에서 공유하기 버튼 기능 활성화 
   - 게스트 → 호스트탭 넘어갈 때 스피너
   - 게스트 마이클래스에서 썸네일 이미지 보이는 위치 수정 (object positon right)
   - 승인 완료가 된 모임에 또 신청하면 또 입금대기로 들어가는 이슈 해결
   - 마감 된 모임에 신청이 가능한 이슈 -> 버튼 비활성화로 해결
   - 카테고리에서 모임 상세 클릭 시 에러뷰 말고 스피너가 보이게
   - 모든 페이지에 스피너가 에러 위로
   - 사파리에서 depositModal 글자 색상 파란색인 이슈 해결
   - 게스트 마이페이지에서 호스트 탭 클릭 시 스피너 뜨게
   - 내가 만든 모임에 내가 참여 가능한 이슈 해결

## 📢 To Reviewers

-

## 📸 스크린샷

<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->
