### PR TITLE
[Feat/#266] 클래스 뷰 - 리뷰 탭 api 연동

### DIFF
--- a/src/apis/domains/review/useFetchMoimReviewList.ts
+++ b/src/apis/domains/review/useFetchMoimReviewList.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
+import { useSuspenseQuery } from '@tanstack/react-query';
 
 import { get } from '@apis/api';
 import { QUERY_KEY } from '@apis/queryKeys/queryKeys';
@@ -19,12 +19,11 @@ const getMoimReviewList = async (moimId: string): Promise<ReviewListGetByMoimRes
   }
 };
 
-export const useFetchMoimReviewList = (moimId: string, selectTab: string) => {
-  return useQuery({
+export const useFetchMoimReviewList = (moimId: string) => {
+  return useSuspenseQuery({
     queryKey: [QUERY_KEY.MOIM_REVIEW_LIST, moimId],
     queryFn: () => getMoimReviewList(moimId),
     staleTime: 1000 * 60,
     gcTime: 1000 * 60 * 5,
-    enabled: selectTab === '리뷰',
   });
 };

--- a/src/apis/domains/review/useFetchMoimReviewList.ts
+++ b/src/apis/domains/review/useFetchMoimReviewList.ts
@@ -1,0 +1,30 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { get } from '@apis/api';
+import { QUERY_KEY } from '@apis/queryKeys/queryKeys';
+
+import { components } from '@schema';
+import { ApiResponseType } from '@types';
+
+type ReviewListGetByMoimResponse = components['schemas']['ReviewListGetByMoimResponse'];
+
+const getMoimReviewList = async (moimId: string): Promise<ReviewListGetByMoimResponse[] | null> => {
+  try {
+    const response = await get<ApiResponseType<ReviewListGetByMoimResponse[]>>(
+      `/v2/moim/${moimId}/review-list`
+    );
+    return response.data.data;
+  } catch (error) {
+    return null;
+  }
+};
+
+export const useFetchMoimReviewList = (moimId: string, selectTab: string) => {
+  return useQuery({
+    queryKey: [QUERY_KEY.MOIM_REVIEW_LIST, moimId],
+    queryFn: () => getMoimReviewList(moimId),
+    staleTime: 1000 * 60,
+    gcTime: 1000 * 60 * 5,
+    enabled: selectTab === '리뷰',
+  });
+};

--- a/src/apis/queryKeys/queryKeys.ts
+++ b/src/apis/queryKeys/queryKeys.ts
@@ -16,6 +16,7 @@ export const QUERY_KEY = {
   MOIM_DESCRIPTION: 'moimDescription',
   MOIM_HOST: 'moimHost',
   MOIM_NOTICE_LIST: 'moimNoticeList',
+  MOIM_REVIEW_LIST: 'moimReviewList',
   MOIM_SUBMIT_REQUEST: 'moimSubmitRequest',
   MOIM_SUBMITTER: 'moimSubmitter',
   POST_MOIM: 'postMoim',

--- a/src/components/common/Review/Review.style.ts
+++ b/src/components/common/Review/Review.style.ts
@@ -64,3 +64,8 @@ export const iconStyle = css`
   width: 2.4rem;
   height: 2.4rem;
 `;
+
+export const timeTextStyle = (theme: Theme) => css`
+  color: ${theme.color.midgray1};
+  ${theme.font['body03-r-12']}
+`;

--- a/src/components/common/Review/Review.tsx
+++ b/src/components/common/Review/Review.tsx
@@ -1,6 +1,7 @@
 import { useNavigate } from 'react-router-dom';
 
 import { IcNext } from '@svg';
+import { formatCreatedDate } from '@utils';
 
 import {
   iconStyle,
@@ -11,44 +12,64 @@ import {
   reviewImgSection,
   reviewLayoutStyle,
   tagsContainer,
+  timeTextStyle,
 } from './Review.style';
 import ReviewTag from '../ReviewTag/ReviewTag';
 import SimpleUserProfile from '../SimpleUserProfile/SimpleUserProfile';
 
-const tags = [
-  '전문성이 있어요',
-  '진행이 매끄러워요',
-  '준비가 철저해요',
-  '시간 관리를 잘해요',
-  '게스트의 반응을 잘 반영해요',
-];
-const moimId = 1;
-const moimTitle = '티엘고마가 알려주는 클래스 성공 비법';
+import { components } from '@schema';
 
-const Review = () => {
+type ReviewListGetByMoimResponse = components['schemas']['ReviewListGetByMoimResponse'];
+type ReviewListGetByHostResponse = components['schemas']['ReviewListGetByHostResponse'];
+
+interface ReviewProps {
+  reviewData: ReviewListGetByMoimResponse | ReviewListGetByHostResponse;
+}
+
+const Review = ({ reviewData }: ReviewProps) => {
+  const {
+    tagList,
+    content,
+    guestNickname,
+    reviewImageUrl,
+    guestImageUrl,
+    date,
+    moimId,
+    moimTitle,
+  } = reviewData as {
+    moimId?: string;
+    moimTitle?: string;
+    tagList: string[] | undefined;
+    content: string;
+    guestNickname: string;
+    reviewImageUrl: string;
+    guestImageUrl: string;
+    date: string;
+  };
   const navigate = useNavigate();
 
   const handleTitleClick = () => {
     navigate(`/class/${moimId}`);
   };
+
   return (
     <div css={reviewLayoutStyle}>
-      <SimpleUserProfile size="large" username="갓민서입니다롱" />
+      <SimpleUserProfile size="large" username={guestNickname ?? ''} userImgUrl={guestImageUrl} />
       <div css={reviewContentContainer}>
-        <p css={reviewContent}>
-          리뷰 내용입니다. 리뷰 내용입니다. 리뷰 내용입니다. 리뷰 내용입니다. 리뷰 내용입니다. 리뷰
-          내용입니다. 리뷰 내용입니다. 리뷰 내용입니다. 리뷰 내용입니다.
-        </p>
+        <p css={reviewContent}>{content}</p>
         <div css={tagsContainer}>
-          {tags.map((tag, i) => (
-            <ReviewTag key={i}>{tag}</ReviewTag>
-          ))}
+          {tagList &&
+            tagList
+              .filter((tag: string) => tag !== 'null')
+              .map((tag: string, i: number) => <ReviewTag key={i}>{tag}</ReviewTag>)}
         </div>
       </div>
       <div css={imgAndTitleContainer}>
-        <div css={reviewImgSection}></div>
+        <div css={reviewImgSection}>
+          {reviewImageUrl && <img src={reviewImageUrl} alt="리뷰 이미지" />}
+        </div>
         {/* 클래스 뷰, 스픽커 소개뷰에서 모두 사용하기 위해 api에서 moimId 유무에 따라 보여주기 위함 */}
-        {moimId && (
+        {moimTitle !== undefined && (
           <div css={moimTitleWrapper} onClick={handleTitleClick}>
             {moimTitle}
             <span css={iconStyle}>
@@ -57,7 +78,7 @@ const Review = () => {
           </div>
         )}
       </div>
-      <span>14시간 전</span>
+      <span css={timeTextStyle}>{formatCreatedDate(date ?? '')}</span>
     </div>
   );
 };

--- a/src/components/common/ReviewTag/ReviewTag.style.ts
+++ b/src/components/common/ReviewTag/ReviewTag.style.ts
@@ -3,7 +3,7 @@ import { Theme, css } from '@emotion/react';
 export const reviewTagContainer = (theme: Theme) => css`
   padding: 0.5rem;
   border-radius: 5px;
-  background-color: ${theme.color.background};
+  background-color: ${theme.color.bg_white0};
   color: ${theme.color.midgray2};
   ${theme.font['body03-r-12']}
   white-space: nowrap;

--- a/src/pages/class/components/ClassReviewTab/ClassReviewTab.style.ts
+++ b/src/pages/class/components/ClassReviewTab/ClassReviewTab.style.ts
@@ -1,0 +1,9 @@
+import { css } from '@emotion/react';
+
+import { flexGenerator } from '@styles/generator';
+
+export const reviewSectionStyle = css`
+  ${flexGenerator('column')}
+  width: 100%;
+  gap: 2rem;
+`;

--- a/src/pages/class/components/ClassReviewTab/ClassReviewTab.tsx
+++ b/src/pages/class/components/ClassReviewTab/ClassReviewTab.tsx
@@ -1,0 +1,25 @@
+import { useFetchMoimReviewList } from '@apis/domains/review/useFetchMoimReviewList';
+
+import Review from 'src/components/common/Review/Review';
+
+import { reviewSectionStyle } from './ClassReviewTab.style';
+import ClassReviewEmptyView from '../ClassReviewEmptyView/ClassReviewEmptyView';
+
+interface ClassReviewTabProps {
+  moimId: string;
+}
+
+const ClassReviewTab = ({ moimId }: ClassReviewTabProps) => {
+  const { data: moimReviewList } = useFetchMoimReviewList(moimId ?? '');
+
+  if ((moimReviewList || []).length === 0) {
+    return <ClassReviewEmptyView />;
+  }
+  return (
+    <section css={reviewSectionStyle}>
+      {moimReviewList?.map((review, i) => <Review key={i} reviewData={review} />)}
+    </section>
+  );
+};
+
+export default ClassReviewTab;

--- a/src/pages/class/page/Class/Class.style.ts
+++ b/src/pages/class/page/Class/Class.style.ts
@@ -66,12 +66,6 @@ export const infoSectionStyle = (theme: Theme) => css`
   background-color: ${theme.color.white};
 `;
 
-export const reviewSectionStyle = css`
-  ${flexGenerator('column')}
-  width: 100%;
-  gap: 2rem;
-`;
-
 export const floatingButtonWrapper = (widowWidth: number) => css`
   position: fixed;
   bottom: 12rem;

--- a/src/pages/class/page/Class/Class.style.ts
+++ b/src/pages/class/page/Class/Class.style.ts
@@ -66,6 +66,12 @@ export const infoSectionStyle = (theme: Theme) => css`
   background-color: ${theme.color.white};
 `;
 
+export const reviewSectionStyle = css`
+  ${flexGenerator('column')}
+  width: 100%;
+  gap: 2rem;
+`;
+
 export const floatingButtonWrapper = (widowWidth: number) => css`
   position: fixed;
   bottom: 12rem;

--- a/src/pages/class/page/Class/Class.tsx
+++ b/src/pages/class/page/Class/Class.tsx
@@ -4,6 +4,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 
 import { useFetchMoimDetail, useFetchMoimDescription } from '@apis/domains/moim';
 import { useFetchMoimNoticeList } from '@apis/domains/notice';
+import { useFetchMoimReviewList } from '@apis/domains/review/useFetchMoimReviewList';
 
 import {
   Button,
@@ -39,6 +40,7 @@ import {
   classNameStyle,
   floatingButtonWrapper,
   infoSectionStyle,
+  reviewSectionStyle,
   tabButtonStyle,
   tabSectionStyle,
   tabWrapper,
@@ -63,8 +65,12 @@ const Class = () => {
     moimId ?? '',
     selectTab
   );
-
-  if (isMoimDetailLoading || isMoimDescriptionLoading) {
+  const { data: moimReviewList, isLoading: isMoimReviewListLoading } = useFetchMoimReviewList(
+    moimId ?? '',
+    selectTab
+  );
+  console.log(moimReviewList);
+  if (isMoimDetailLoading || isMoimDescriptionLoading || isMoimReviewListLoading) {
     return <Spinner />;
   }
 
@@ -158,8 +164,16 @@ const Class = () => {
             ) : (
               <ClassNotice noticeData={moimNoticeList || []} />
             ))}
-          {/* {selectTab === '리뷰' && <ClassReviewEmptyView />} */}
-          {selectTab === '리뷰' && <Review />}
+          {selectTab === '리뷰' &&
+            (isMoimReviewListLoading ? (
+              <Spinner variant="component" />
+            ) : (moimReviewList || []).length === 0 ? (
+              <ClassReviewEmptyView />
+            ) : (
+              <section css={reviewSectionStyle}>
+                {moimReviewList?.map((review, i) => <Review key={i} reviewData={review} />)}
+              </section>
+            ))}
         </section>
         {selectTab === '공지사항' && moimDetail?.hostId === hostId && (
           <div

--- a/src/pages/class/page/Class/Class.tsx
+++ b/src/pages/class/page/Class/Class.tsx
@@ -69,7 +69,6 @@ const Class = () => {
     moimId ?? '',
     selectTab
   );
-  console.log(moimReviewList);
   if (isMoimDetailLoading || isMoimDescriptionLoading || isMoimReviewListLoading) {
     return <Spinner />;
   }

--- a/src/pages/class/page/Class/Class.tsx
+++ b/src/pages/class/page/Class/Class.tsx
@@ -4,7 +4,6 @@ import { useNavigate, useParams } from 'react-router-dom';
 
 import { useFetchMoimDetail, useFetchMoimDescription } from '@apis/domains/moim';
 import { useFetchMoimNoticeList } from '@apis/domains/notice';
-import { useFetchMoimReviewList } from '@apis/domains/review/useFetchMoimReviewList';
 
 import {
   Button,
@@ -22,14 +21,13 @@ import {
   ClassInfo,
   ClassNotice,
   ClassNoticeEmptyView,
-  ClassReviewEmptyView,
   HostInfoCard,
 } from '@pages/class/components';
+import ClassReviewTab from '@pages/class/components/ClassReviewTab/ClassReviewTab';
 import Error from '@pages/error/Error';
 import { userAtom } from '@stores';
 import { IcClassPerson, IcCopyPlus, IcDate, IcMoney, IcOffline, IcOneline } from '@svg';
 import { dDayText, handleShare, smoothScroll } from '@utils';
-import Review from 'src/components/common/Review/Review';
 
 import {
   buttonContainer,
@@ -40,7 +38,6 @@ import {
   classNameStyle,
   floatingButtonWrapper,
   infoSectionStyle,
-  reviewSectionStyle,
   tabButtonStyle,
   tabSectionStyle,
   tabWrapper,
@@ -65,11 +62,7 @@ const Class = () => {
     moimId ?? '',
     selectTab
   );
-  const { data: moimReviewList, isLoading: isMoimReviewListLoading } = useFetchMoimReviewList(
-    moimId ?? '',
-    selectTab
-  );
-  if (isMoimDetailLoading || isMoimDescriptionLoading || isMoimReviewListLoading) {
+  if (isMoimDetailLoading || isMoimDescriptionLoading) {
     return <Spinner />;
   }
 
@@ -163,16 +156,7 @@ const Class = () => {
             ) : (
               <ClassNotice noticeData={moimNoticeList || []} />
             ))}
-          {selectTab === '리뷰' &&
-            (isMoimReviewListLoading ? (
-              <Spinner variant="component" />
-            ) : (moimReviewList || []).length === 0 ? (
-              <ClassReviewEmptyView />
-            ) : (
-              <section css={reviewSectionStyle}>
-                {moimReviewList?.map((review, i) => <Review key={i} reviewData={review} />)}
-              </section>
-            ))}
+          {selectTab === '리뷰' && <ClassReviewTab moimId={moimId ?? ''} />}
         </section>
         {selectTab === '공지사항' && moimDetail?.hostId === hostId && (
           <div


### PR DESCRIPTION
<!-- PR의 제목은 "[Feat/#1] 로그인 기능 추가" 와 같이 작성해주세요! -->

## 📌 관련 이슈번호

- Closes #266 
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

## ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 내용
   - 클래스 상세 뷰의 리뷰 탭을 클릭했을 시 보이는 리뷰들을 가져오는 api를 연동했습니다.
   - 우선 리뷰 데이터 리스트를 가져오는 get api 완료했고
   - 이를 공지사항 탭과 같은 방식으로 map돌려서 화면에 보이게 했습니다.
   - 데이터 바인딩 하는 과정에서 개인적으로 살짝 복잡한게 있었는데 이 Review 컴포넌트가 해당 클래스 뷰의 리뷰 탭에서도 사용되고, 스픽커 소개페이지에서도 사용됩니다. 하지만 스픽커 소개페이지에서는 다른 api를 사용하는데 여기에는 추가적으로 moimId, moimTitle 값을 넘겨받습니다. 그렇기 때문에 같은 컴포넌트를 쓰지만 moimId, moimTitle을 옵셔널로 받기 위해서 처음에는 
 ```
interface ReviewProps {
  reviewData: {
    moimId?: string;
    moimTitle?: string;
    tagList: string[] | undefined;
    content: string;
    guestNickname: string;
    reviewImageUrl: string;
    guestImageUrl: string;
    date: string;
  };
}
```
이처럼 prop에서 moimId, moimTitle을 옵셔널로 지정해줬습니다. 그랬더니 Class 컴포넌트에서 map을 돌려서 이 Review 컴포넌트를 호출하는 부분에서 reviewData를 넘겨줄 때 타입에러가 발생했습니다. 저희가 쓰는 스키마에서의 tagList 타입은 `Record<string, never>[]` 이런건데 제가 `string[] | undefined` 으로 타입을 지정해놔서 그런것 같아요. 그래서 지금과 같이 prop으로 받는 부분은 타입을 스키마를 사용해서 지정해주고, 추후 구조분해할당 할 때 타입 단언을 통해 수정해주었습니다.

## 📢 To Reviewers

-

## 📸 스크린샷
<img width="449" alt="image" src="https://github.com/user-attachments/assets/55196c02-57ee-4a07-80cb-150d01a3e80e">

<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->
