### PR TITLE
[Feat/#268] presigned url 타입 수정 및 인자 위치 수정

### DIFF
--- a/src/apis/domains/presignedUrl/usePostPresignedUrl.ts
+++ b/src/apis/domains/presignedUrl/usePostPresignedUrl.ts
@@ -1,9 +1,9 @@
-import { get } from '@apis/api';
+import { post } from '@apis/api';
 
 import { components } from '@schema';
 import { ApiResponseType } from '@types';
 
-type PreSignedUrlClientRequest = components['schemas']['PreSignedUrlClientRequest'];
+type PreSignedUrlResponse = components['schemas']['PreSignedUrlResponse'];
 
 export type PresignedPrefixType =
   | 'MOIM_PREFIX'
@@ -11,13 +11,13 @@ export type PresignedPrefixType =
   | 'REVIEW_PREFIX'
   | 'HOST_PROFILE_PREFIX';
 
-export const getPresignedUrl = async (
+export const postPresignedUrl = async (
   prefix: PresignedPrefixType,
   count: number
-): Promise<PreSignedUrlClientRequest[] | null> => {
+): Promise<PreSignedUrlResponse[] | null> => {
   try {
-    const response = await get<ApiResponseType<PreSignedUrlClientRequest[]>>(`/v2/image/upload`, {
-      params: {
+    const response = await post<ApiResponseType<PreSignedUrlResponse[]>>(`/v2/image/upload`, {
+      body: {
         prefix,
         count,
       },

--- a/src/utils/image.ts
+++ b/src/utils/image.ts
@@ -1,12 +1,15 @@
 import { QueryClient } from '@tanstack/react-query';
 
-import { getPresignedUrl, PresignedUrlType } from '@apis/domains/presignedUrl/useFetchPresignedUrl';
 import { PutImageUploadParams } from '@apis/domains/presignedUrl/usePutS3Upload';
+import {
+  postPresignedUrl,
+  PresignedPrefixType,
+} from '@apis/domains/presignedUrl/usePostPresignedUrl';
 
 interface UploadParams {
   selectedFiles: File[];
   putS3Upload: (params: PutImageUploadParams) => Promise<void>;
-  type: PresignedUrlType;
+  type: PresignedPrefixType;
 }
 
 export const handleUpload = async ({
@@ -24,7 +27,7 @@ export const handleUpload = async ({
   if (selectedFiles.length > 0) {
     const presignedUrls = await queryClient.fetchQuery({
       queryKey: ['presignedUrl', selectedFiles.length],
-      queryFn: () => getPresignedUrl(selectedFiles.length, type),
+      queryFn: () => postPresignedUrl(type, selectedFiles.length),
     });
 
     if (presignedUrls && presignedUrls.length > 0) {


### PR DESCRIPTION
<!-- PR의 제목은 "[Feat/#1] 로그인 기능 추가" 와 같이 작성해주세요! -->

## 📌 관련 이슈번호

- Closes #268 
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

## ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 내용
   - presigned Url에서 리턴 타입이 filename과 url이 아니고 다른 타입으로 되어있더라구요. 그 부분 수정했습니다
   - image 유틸 함수에서 함수 인자 위치 수정하였습니다.
   - 서버에서 GET대신 POST로 수정하였기 때문에 그 부분 따라 수정완료하였고, params로 보내주는 것이 아닌 body에 보내게 수정하였습니다.

## 📢 To Reviewers

-

## 📸 스크린샷

<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->
