### PR TITLE
[Fix/#283] HostInfoCard hotfix

### DIFF
--- a/src/pages/class/components/HostInfoCard/HostInfoCard.style.ts
+++ b/src/pages/class/components/HostInfoCard/HostInfoCard.style.ts
@@ -10,13 +10,13 @@ export const hostInfoWrapper = (theme: Theme) => css`
   border: 1px solid ${theme.color.lightgray0};
   border-radius: 10px;
   width: 100%;
-  height: 9.7rem;
-  padding: 1rem;
-  border-radius: 10px;
-  background-color: ${theme.color.bg_white0};
+  height: 10.4rem;
+
+  cursor: pointer;
 `;
 
 export const hostProfileWrapper = css`
+  height: 100%;
   ${flexGenerator('column', 'center', 'flex-start')};
   gap: 0.2rem;
 `;
@@ -24,6 +24,7 @@ export const hostProfileWrapper = css`
 export const hostNameMarkWrapper = css`
   ${flexGenerator()}
   gap: 0.8rem;
+  margin: 0.1rem 0;
 `;
 
 export const hostNameWrapper = css`
@@ -46,7 +47,7 @@ export const hostMarkMessageWrapper = (theme: Theme) => css`
 
 export const hostMarkMessageStyle = (theme: Theme) => css`
   color: ${theme.color.purple1};
-  ${theme.font['body03-r-12']}
+  ${theme.font['body03-r-12']};
 `;
 
 export const hostNameStyle = (theme: Theme) => css`
@@ -56,10 +57,18 @@ export const hostNameStyle = (theme: Theme) => css`
 
 export const hostKeywordStyle = (theme: Theme) => css`
   color: ${theme.color.purple2};
-  ${theme.font['body03-r-12']}
+  ${theme.font['body03-r-12']};
+  line-height: 140%;
 `;
 
 export const hostDescriptionWrapper = (theme: Theme) => css`
   color: ${theme.color.midgray2};
   ${theme.font['body03-r-12']};
+  line-height: 140%;
+
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
 `;

--- a/src/pages/class/components/HostInfoCard/HostInfoCard.tsx
+++ b/src/pages/class/components/HostInfoCard/HostInfoCard.tsx
@@ -1,3 +1,5 @@
+import { useNavigate } from 'react-router-dom';
+
 import { useFetchMoimHost } from '@apis/domains/host';
 
 import { Image } from '@components';
@@ -25,9 +27,13 @@ const HostInfoCard = ({ hostId }: HostInfoCardProps) => {
   const { data: moimHostData } = useFetchMoimHost(hostId);
 
   const { hostNickName, hostImageUrl, count, keyword, description } = moimHostData ?? {};
+  const navigate = useNavigate();
 
+  const handleHostInfoClick = () => {
+    navigate(`/host/info/${hostId}`);
+  };
   return (
-    <article css={hostInfoWrapper}>
+    <article css={hostInfoWrapper} onClick={handleHostInfoClick}>
       <Image variant="round" width="6rem" src={images.HostProfileImage || hostImageUrl} />
 
       <section css={hostProfileWrapper}>


### PR DESCRIPTION
<!-- PR의 제목은 "[Feat/#1] 로그인 기능 추가" 와 같이 작성해주세요! -->

## 📌 관련 이슈번호

- Closes #283
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

## ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. HostInfoCard 눌렀을 때 스픽커 소개 페이지로 이동
   - 원래 onClick이 안되어있어서 추가함.
2. style도 조금 다르길래 수정했음.
  - 글씨체를 body03을 쓰고있는데 line-height가 140%로 설정되어있음. 원래 body03은 line-height가 140%가 아님.
  - 일단은 body03에 line-height속성만 추가해서 설정해둠. **디자인과 논의 필요**

## 📢 To Reviewers

- QA를 해야하는데, 크리티컬한 이슈로 판단되어 바로 수정하고 머지하도록 하겠습니다.
- onClick함수(navigate기능만 함) 추가와, 간단한 style수정만 있었습니다.

## 📸 스크린샷

https://github.com/user-attachments/assets/bdd8c42c-b985-43ad-9de7-00f486be27c7

