### PR TITLE
[Fix/#290] 입금 모달 수정

### DIFF
--- a/src/components/common/Review/Review.tsx
+++ b/src/components/common/Review/Review.tsx
@@ -65,9 +65,11 @@ const Review = ({ reviewData }: ReviewProps) => {
         </div>
       </div>
       <div css={imgAndTitleContainer}>
-        <div css={reviewImgSection}>
-          {reviewImageUrl && <img src={reviewImageUrl} alt="리뷰 이미지" />}
-        </div>
+        {reviewImageUrl && (
+          <div css={reviewImgSection}>
+            <img src={reviewImageUrl} alt="리뷰 이미지" />
+          </div>
+        )}
         {/* 클래스 뷰, 스픽커 소개뷰에서 모두 사용하기 위해 api에서 moimId 유무에 따라 보여주기 위함 */}
         {moimTitle !== undefined && (
           <div css={moimTitleWrapper} onClick={handleTitleClick}>

--- a/src/pages/class/page/ClassApply/ClassApplyDeposit/ClassApplyDeposit.style.ts
+++ b/src/pages/class/page/ClassApply/ClassApplyDeposit/ClassApplyDeposit.style.ts
@@ -36,14 +36,3 @@ export const depositFooterStyle = css`
   width: 100%;
   margin-top: auto;
 `;
-
-export const depositCautionTextStyle = (theme: Theme) => css`
-  padding: 0;
-  background-color: transparent;
-  color: ${theme.color.midgray1};
-  border: none;
-  border-bottom: 1px solid ${theme.color.midgray1};
-  ${theme.font['subhead03-m-16']}
-
-  cursor: pointer;
-`;

--- a/src/pages/class/page/ClassApply/ClassApplyDeposit/ClassApplyDeposit.tsx
+++ b/src/pages/class/page/ClassApply/ClassApplyDeposit/ClassApplyDeposit.tsx
@@ -4,12 +4,9 @@ import { useParams } from 'react-router-dom';
 import { Button } from '@components';
 import { GuestClassRegisterCard } from '@pages/class/components';
 import { ClassApplyProps } from '@pages/class/page/ClassApply/ClassApplyRule/ClassApplyRule';
-import DepositErrorModal from '@pages/guest/components/DepositErrorModal/DepositErrorModal';
-import AbsoluteModal from 'src/components/common/AbsoluteModal/AbsoluteModal';
 
 import {
   depositArticleLayout,
-  depositCautionTextStyle,
   depositFooterStyle,
   depositHStyle,
   depositSpanStyle,
@@ -20,7 +17,6 @@ import {
 import { MoimIdPathParameterType } from '@types';
 
 const ClassApplyDeposit = ({ handlePageChange }: ClassApplyProps) => {
-  const [isErrorModalOpen, setIsErrorModalOpen] = useState(false);
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   const { moimId } = useParams<MoimIdPathParameterType>();
@@ -32,51 +28,32 @@ const ClassApplyDeposit = ({ handlePageChange }: ClassApplyProps) => {
     setIsModalOpen(false);
   };
 
-  const handleErrorModalOpen = () => {
-    setIsErrorModalOpen(true);
-  };
-
-  const handleErrorModalClose = () => {
-    setIsErrorModalOpen(false);
-  };
-
   return (
-    <>
-      <article css={depositArticleLayout}>
-        <div css={dipositWrapperStyle}>
-          <header>
-            <span css={depositSpanStyle}>클래스 모임 신청</span>
-            <h1 css={depositHStyle}>
-              클래스 신청이 완료되었습니다! <br /> 이제 참가비를 입금해주세요.
-            </h1>
-          </header>
+    <article css={depositArticleLayout}>
+      <div css={dipositWrapperStyle}>
+        <header>
+          <span css={depositSpanStyle}>클래스 모임 신청</span>
+          <h1 css={depositHStyle}>
+            클래스 신청이 완료되었습니다! <br /> 이제 참가비를 입금해주세요.
+          </h1>
+        </header>
 
-          <main css={depositMainStyle}>
-            <GuestClassRegisterCard
-              moimId={moimId ?? ''}
-              isModalOpen={isModalOpen}
-              handleModalClose={handleModalClose}
-              handlePageChange={handlePageChange}
-            />
-          </main>
-        </div>
+        <main css={depositMainStyle}>
+          <GuestClassRegisterCard
+            moimId={moimId ?? ''}
+            isModalOpen={isModalOpen}
+            handleModalClose={handleModalClose}
+            handlePageChange={handlePageChange}
+          />
+        </main>
+      </div>
 
-        <footer css={depositFooterStyle}>
-          <Button variant="large" onClick={handleModalOpen}>
-            입금하기
-          </Button>
-          <button css={depositCautionTextStyle} onClick={handleErrorModalOpen}>
-            입금에 문제가 생기셨나요?
-          </button>
-        </footer>
-      </article>
-
-      {isErrorModalOpen && (
-        <AbsoluteModal onClose={handleErrorModalClose}>
-          <DepositErrorModal onClose={handleErrorModalClose} />
-        </AbsoluteModal>
-      )}
-    </>
+      <footer css={depositFooterStyle}>
+        <Button variant="large" onClick={handleModalOpen}>
+          입금하기
+        </Button>
+      </footer>
+    </article>
   );
 };
 

--- a/src/pages/guest/components/DepositErrorModal/DepositErrorModal.style.ts
+++ b/src/pages/guest/components/DepositErrorModal/DepositErrorModal.style.ts
@@ -8,12 +8,13 @@ export const modalContainerStyle = (theme: Theme) => css`
   z-index: 5;
   border: 1px solid ${theme.color.lightgray2};
   border-radius: 10px;
+  background-color: ${theme.color.white};
 `;
 export const articleStyle = css`
   ${flexGenerator('column')}
   width: 27.8rem;
   gap: 2rem;
-  padding: 2rem 1.8rem 4.8rem 1.8rem;
+  padding: 1.8rem 1.8rem 4.9rem 1.8rem;
 `;
 
 export const headerStyle = css`
@@ -28,6 +29,7 @@ export const iconStyle = css`
 
 export const mainStyle = css`
   ${flexGenerator('column')};
+  width: 100%;
   gap: 1.7rem;
 `;
 

--- a/src/pages/guest/components/DepositErrorModal/DepositErrorModal.tsx
+++ b/src/pages/guest/components/DepositErrorModal/DepositErrorModal.tsx
@@ -38,9 +38,9 @@ const DepositErrorModal = ({ onClose }: DepositErrorModalProps) => {
             <span css={purpleStyle}>스 모임]</span>에서 입금을 진행할 수 있어요.
           </div>
           <div css={bodyTextStyle}>
-            신청 마감일 이전에 입금을 하지 않으
+            신청 마감일 이전에 입금을 하지 않으면,
             <br />
-            면, 클래스에 참가할 수 없으니 유의해 주세요!
+            클래스에 참가할 수 없으니 유의해 주세요!
           </div>
         </main>
       </article>

--- a/src/pages/guest/components/DepositModal/DepositModal.style.ts
+++ b/src/pages/guest/components/DepositModal/DepositModal.style.ts
@@ -4,12 +4,20 @@ import { flexGenerator } from '@styles/generator';
 
 export const modalContainerStyle = css`
   ${flexGenerator('column')}
-  gap: 2.5rem;
-  padding: 4rem 1.7rem 1.7rem 1.7rem;
+  padding: 1.8rem 1.7rem 1.3rem;
+`;
+export const closeIconLayout = css`
+  ${flexGenerator('row', 'end', 'center')}
+  width: 100%;
+`;
+export const closeIconStyle = css`
+  width: 2.4rem;
+  height: 2.4rem;
 `;
 export const headerstyle = css`
   ${flexGenerator('column')}
   gap: 1rem;
+  margin-top: 0.8rem;
 `;
 export const headerFirstH1Style = css`
   ${flexGenerator()}
@@ -34,6 +42,7 @@ export const headerSpanStyle = (theme: Theme) => css`
 export const mainStyle = css`
   ${flexGenerator('column')}
   gap: 1.4rem;
+  margin-top: 2.2rem;
 `;
 
 export const mainFirstSectionStyle = (theme: Theme) => css`
@@ -67,4 +76,29 @@ export const payButtonSectionStyle = css`
 
 export const completeButtonCustomStyle = (theme: Theme) => css`
   ${theme.font['subhead05-sb-14']}
+`;
+
+export const depositErrorButtonWrapper = css`
+  ${flexGenerator()}
+  width: 100%;
+  margin-top: 1.5rem;
+  margin-bottom: 0.5rem;
+  position: relative;
+`;
+export const depositErrorButtonStyle = (theme: Theme) => css`
+  padding: 0;
+  background-color: transparent;
+  color: ${theme.color.midgray1};
+  border: none;
+  border-bottom: 1px solid ${theme.color.midgray1};
+  ${theme.font['subhead03-m-16']}
+
+  cursor: pointer;
+`;
+
+export const depositErrorModalStyle = css`
+  position: absolute;
+  bottom: 4rem;
+  left: 50%;
+  transform: translateX(-50%);
 `;

--- a/src/pages/guest/components/DepositModal/DepositModal.tsx
+++ b/src/pages/guest/components/DepositModal/DepositModal.tsx
@@ -1,11 +1,19 @@
+import { useState } from 'react';
+
 import { Button, ClipboardCopyButton, PayButton } from '@components';
+import { IcClose } from '@svg';
 
 import {
   accountHolderNameStyle,
   accountHolderStyle,
   accountInfoStyle,
   bankTextStyle,
+  closeIconLayout,
+  closeIconStyle,
   completeButtonCustomStyle,
+  depositErrorButtonStyle,
+  depositErrorButtonWrapper,
+  depositErrorModalStyle,
   headerFirstH1Style,
   headerH1SpanStyle,
   headerSecondH1Style,
@@ -16,6 +24,7 @@ import {
   modalContainerStyle,
   payButtonSectionStyle,
 } from './DepositModal.style';
+import DepositErrorModal from '../DepositErrorModal/DepositErrorModal';
 
 interface DepositModalProps {
   onClose: () => void;
@@ -23,38 +32,62 @@ interface DepositModalProps {
 }
 
 const DepositModal = ({ onClose, fee }: DepositModalProps) => {
+  const [isErrorModalOpen, setIsErrorModalOpen] = useState(false);
+  const handleErrorModalToggle = () => {
+    setIsErrorModalOpen((prev) => !prev);
+  };
+  const handleErrorModalClose = () => {
+    setIsErrorModalOpen(false);
+  };
   return (
-    <article css={modalContainerStyle}>
-      <header css={headerstyle}>
-        <h1 css={headerFirstH1Style}>
-          <span css={headerH1SpanStyle}>아래 계좌로 입금해주세요!</span>
-        </h1>
-        <h1 css={headerSecondH1Style}>
-          <span>반드시 입금자명을</span>
-          <span>
-            <span css={headerSpanStyle}>본인 이름</span>으로 설정해 주세요.
+    <>
+      <article css={modalContainerStyle}>
+        <div css={closeIconLayout}>
+          <span css={closeIconStyle}>
+            <IcClose />
           </span>
-        </h1>
-      </header>
-      <main css={mainStyle}>
-        <section css={mainFirstSectionStyle}>
-          <div css={accountInfoStyle}>
-            <h4 css={bankTextStyle}>농협은행</h4>
-            <ClipboardCopyButton />
-          </div>
-          <div css={accountHolderStyle}>
-            예금주 <span css={accountHolderNameStyle}>조소빈</span>
-          </div>
-        </section>
-        <section css={payButtonSectionStyle}>
-          <PayButton variant="kakao" totalPrice={fee || 0} />
-          <PayButton variant="toss" totalPrice={fee || 0} />
-        </section>
-        <Button variant="medium" onClick={onClose} customStyle={completeButtonCustomStyle}>
-          입금을 완료했어요
-        </Button>
-      </main>
-    </article>
+        </div>
+        <header css={headerstyle}>
+          <h1 css={headerFirstH1Style}>
+            <span css={headerH1SpanStyle}>아래 계좌로 입금해주세요!</span>
+          </h1>
+          <h1 css={headerSecondH1Style}>
+            <span>반드시 입금자명을</span>
+            <span>
+              <span css={headerSpanStyle}>닉네임</span>으로 변경해 주세요.
+            </span>
+          </h1>
+        </header>
+        <main css={mainStyle}>
+          <section css={mainFirstSectionStyle}>
+            <div css={accountInfoStyle}>
+              <h4 css={bankTextStyle}>농협은행</h4>
+              <ClipboardCopyButton />
+            </div>
+            <div css={accountHolderStyle}>
+              예금주 <span css={accountHolderNameStyle}>조소빈</span>
+            </div>
+          </section>
+          <section css={payButtonSectionStyle}>
+            <PayButton variant="kakao" totalPrice={fee || 0} />
+            <PayButton variant="toss" totalPrice={fee || 0} />
+          </section>
+          <Button variant="medium" onClick={onClose} customStyle={completeButtonCustomStyle}>
+            입금을 완료했어요
+          </Button>
+        </main>
+        <div css={depositErrorButtonWrapper}>
+          <button css={depositErrorButtonStyle} onClick={handleErrorModalToggle}>
+            입금에 문제가 생기셨나요?
+          </button>
+          {isErrorModalOpen && (
+            <div css={depositErrorModalStyle}>
+              <DepositErrorModal onClose={handleErrorModalClose} />
+            </div>
+          )}
+        </div>
+      </article>
+    </>
   );
 };
 


### PR DESCRIPTION
<!-- PR의 제목은 "[Feat/#1] 로그인 기능 추가" 와 같이 작성해주세요! -->

## 📌 관련 이슈번호

- Closes #290 
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

## ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 내용
   - 입금 모달 이전 페이지에서 입금에 문제가 생겼을 때 띄우는 모달을 입금 모달 내부로 옮겼습니다.
   - 리뷰 컴포넌트에서 사용자가 이미지를 올리지 않았을 시 이미지 section 안뜨게 했습니다.

## 📢 To Reviewers

- 기존에 페이지 컴포넌트에서 입금에 문제가 생기셨나요? 모달을 띄울때는 페이지 height의 bottom 기준으로 고정된 값을 줬는데 모달 내부로 옮기다보니 그게 불가능해졌습니다. 그래서 실제로는 모달은 아니고 그냥 요소를 absolute로 띄우는 방식으로 수정했습니다. 
- 추가로 리뷰 컴포넌트 수정한것도 사소한거라 여기서 빠르게 진행했습니다!

## 📸 스크린샷
<img width="293" alt="image" src="https://github.com/user-attachments/assets/fbd9561b-1c27-4827-aa66-e6222d082548">


<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->
