### PR TITLE
[Fix/#325] 진짜 마지막 QA

### DIFF
--- a/src/pages/guest/page/GuestMyClass/GuestMyClass.tsx
+++ b/src/pages/guest/page/GuestMyClass/GuestMyClass.tsx
@@ -64,6 +64,21 @@ const GuestMyClass = () => {
     '환불 완료': currentData?.filter((data) => data.moimSubmissionState === 'refunded'),
   };
 
+  const GuestMyClassEmptyViewText = (state: string) => {
+    switch (state) {
+      case '전체': {
+        return '아직 신청한 클래스가 없어요';
+      }
+      case '입금 대기':
+      case '승인 대기': {
+        return `${state} 중인 클래스가 없어요`;
+      }
+      default: {
+        return `${state}된 클래스가 없어요`;
+      }
+    }
+  };
+
   if (isApplyLoading || isParticipateLoading) {
     return <Spinner />;
   }
@@ -112,9 +127,7 @@ const GuestMyClass = () => {
             <GuestMyClassEmptyView
               text={
                 activeTab === '신청한'
-                  ? selectedStatus === '입금 대기' || selectedStatus === '승인 대기'
-                    ? `${selectedStatus} 중인 클래스가 없어요`
-                    : `${selectedStatus}된 클래스가 없어요`
+                  ? GuestMyClassEmptyViewText(selectedStatus)
                   : '아직 참가한 클래스가 없어요'
               }
             />

--- a/src/pages/home/page/Home/Home.tsx
+++ b/src/pages/home/page/Home/Home.tsx
@@ -84,13 +84,19 @@ const Home = () => {
               modules={[Pagination]}
               loop={true}
               className="mySwiper">
-              {bannerList.map((banner, index) => {
-                return (
-                  <SwiperSlide key={banner.id} onClick={() => handleBannerClick(index)}>
-                    <Lottie animationData={banner.animationData} width={'100%'} loop={true} />
-                  </SwiperSlide>
-                );
-              })}
+              {bannerId ? (
+                bannerList.map((banner, index) => {
+                  return (
+                    <SwiperSlide key={banner.id} onClick={() => handleBannerClick(index)}>
+                      <Lottie animationData={banner.animationData} width={'100%'} loop={true} />
+                    </SwiperSlide>
+                  );
+                })
+              ) : (
+                <SwiperSlide onClick={() => handleBannerClick(1)}>
+                  <Lottie animationData={bannerList[1].animationData} width={'100%'} loop={true} />
+                </SwiperSlide>
+              )}
             </Swiper>
           </div>
           <div css={categoryContainer}>


### PR DESCRIPTION
<!-- PR의 제목은 "[Feat/#1] 로그인 기능 추가" 와 같이 작성해주세요! -->

## 📌 관련 이슈번호

- Closes #325
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

---

## 체크리스트

- [x] 🎋 base 브랜치를 develop 브랜치로 설정했나요?
- [x] 🖌️ PR 제목은 형식에 맞게 잘 작성했나요? <!-- e.g. [Feat/#1] 로그인 기능 추가 -->
- [x] 🏗️ 빌드는 성공했나요? (yarn build)
- [x] 🧹 불필요한 코드는 제거했나요? e.g. console.log
- [x] 🙇‍♂️ 리뷰어를 지정했나요? 
- [x] 🏷️ 라벨은 등록했나요?

---

## ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 메인 홈에서 등록된 모임이 없을 때, 첫번째 배너를 클릭하면 오류 페이지 뜨는 문제 해결
   - bannerId가 내려올 때만 bannerList map 돌도록 했고
   - bannerId가 null 일 땐 호스트 관련 배너만 보이도록 했습니다!
 
2. 게스트의 신청 중인 모임 화면에서, 신청한 모임이 없을 때, 필터 셀렉터에서 '전체'를 선택하면 '전체된 모임이 없어요' 라는 문구 뜨는 문제 해결 
   - '전체'일 경우: '아직 신청한 클래스가 없어요'
   - '입금 대기', '승인 대기'일 경우: `${state} 중인 클래스가 없어요`
   - 나머지: `${state}된 클래스가 없어요`


---

## 📢 To Reviewers

-

---

## 📸 스크린샷 or 실행영상

- bannerId가 있을 경우
<img width="448" alt="스크린샷 2024-09-23 오전 1 08 17" src="https://github.com/user-attachments/assets/91352fb0-7fe1-441a-becb-438e7e9ac7c6">

- bannerId가 없을 경우
<img width="457" alt="스크린샷 2024-09-23 오전 1 08 45" src="https://github.com/user-attachments/assets/687befc0-cf67-4bd2-bb63-9bea43c6070f">

- 필터 셀렉터 '전체' 선택
<img width="457" alt="스크린샷 2024-09-23 오전 1 11 04" src="https://github.com/user-attachments/assets/95c1aa38-bed7-4536-8ab0-570f5809e02a">


- 필터 셀렉터 '입금 대기', '신청 대기' 선택
<img width="457" alt="스크린샷 2024-09-23 오전 1 11 09" src="https://github.com/user-attachments/assets/5dd0db91-bcb5-4b50-8ce8-29654b16ddfa">
<img width="457" alt="스크린샷 2024-09-23 오전 1 11 14" src="https://github.com/user-attachments/assets/18203280-2cc9-4354-ba45-cf0680d3baba">


- 필터 셀렉터 나머지 선택
<img width="457" alt="스크린샷 2024-09-23 오전 1 11 25" src="https://github.com/user-attachments/assets/a6b6b63d-3b6e-4960-ac08-ce438fab46a2">



<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->
