### PR TITLE
[Fix/#332] 클래스 개설 후 조타이 초기화

### DIFF
--- a/src/pages/class/components/StepThree/StepThree.tsx
+++ b/src/pages/class/components/StepThree/StepThree.tsx
@@ -27,7 +27,7 @@ import {
 import { ErrorType } from '@types';
 
 const StepThree = ({ onNext }: StepProps) => {
-  const { classPostState, handleInputChange } = useClassPostInputChange();
+  const { classPostState, handleInputChange, resetClassPostState } = useClassPostInputChange();
   const [, setMoimId] = useAtom(moimIdAtom);
   const { validateStepThree } = useClassPostInputValidation();
   const { isTitleValid, isDescriptionValid } = validateStepThree(classPostState);
@@ -58,6 +58,7 @@ const StepThree = ({ onNext }: StepProps) => {
             setMoimId(data);
           }
           onNext();
+          resetClassPostState();
           smoothScroll(0);
         })
         .catch((error: ErrorType) => {

--- a/src/pages/class/hooks/useClassPostInputChange.ts
+++ b/src/pages/class/hooks/useClassPostInputChange.ts
@@ -95,6 +95,38 @@ const useClassPostInputChange = () => {
     }));
   };
 
+  const resetClassPostState = () => {
+    setClassPostState({
+      categoryList: {
+        category1: '',
+        category2: '',
+        category3: '',
+      },
+      isOffline: true,
+      offlineSpot: '',
+      onlineSpot: '',
+      date: '',
+      dayOfWeek: '',
+      startTime: '',
+      endTime: '',
+      maxGuest: 7,
+      fee: 0,
+      accountList: {
+        holder: '',
+        bank: '',
+        accountNumber: '',
+      },
+      questionList: {
+        question1: '',
+        question2: '',
+        question3: '',
+      },
+      title: '',
+      description: '',
+      imageList: [],
+    });
+  };
+
   return {
     classPostState,
     handleInputChange,
@@ -106,6 +138,7 @@ const useClassPostInputChange = () => {
     handleAccountChange,
     handleDateChange,
     handleQuestionChange,
+    resetClassPostState,
   };
 };
 


### PR DESCRIPTION
<!-- PR의 제목은 "[Feat/#1] 로그인 기능 추가" 와 같이 작성해주세요! -->

## 📌 관련 이슈번호

- Closes #332 
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

---

## 체크리스트

- [x] 🎋 base 브랜치를 develop 브랜치로 설정했나요?
- [x] 🖌️ PR 제목은 형식에 맞게 잘 작성했나요? <!-- e.g. [Feat/#1] 로그인 기능 추가 -->
- [x] 🏗️ 빌드는 성공했나요? (yarn build)
- [x] 🧹 불필요한 코드는 제거했나요? e.g. console.log
- [x] 🙇‍♂️ 리뷰어를 지정했나요? 
- [x] 🏷️ 라벨은 등록했나요?

---

## ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 조타이 atom 초기화
   - 클래스 개설 후 조타이를 초기화 시켜서 이전페이지로 돌아가면 값을 불러오지 못하게 막습니다.


---

## 📢 To Reviewers

-

---

## 📸 스크린샷 or 실행영상

<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->
