### PR TITLE
[Fix/#340] 토큰 재발급 오류 hotfix

### DIFF
--- a/src/apis/api.ts
+++ b/src/apis/api.ts
@@ -66,8 +66,13 @@ const fetchAccessToken = async (): Promise<string | null> => {
     const axiosError = error as AxiosError<ErrorType>;
     const errorData = axiosError.response?.data;
 
-    // 리프레시 토큰 만료 시. 로그아웃 처리
-    if (errorData?.status === 40101) {
+    // 리프레시 토큰 재발급 오류 시. 로그아웃 처리
+    if (
+      errorData?.status === 40101 ||
+      errorData?.status === 40102 ||
+      errorData?.status === 40103 ||
+      errorData?.status === 40104
+    ) {
       console.error('리프레시 토큰 만료:', errorData);
       clearLocalStorage();
       window.location.href = '/login';


### PR DESCRIPTION
<!-- PR의 제목은 "[Feat/#1] 로그인 기능 추가" 와 같이 작성해주세요! -->

## 📌 관련 이슈번호

- Closes #340 
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

---

## 체크리스트

- [x] 🎋 base 브랜치를 develop 브랜치로 설정했나요?
- [x] 🖌️ PR 제목은 형식에 맞게 잘 작성했나요? <!-- e.g. [Feat/#1] 로그인 기능 추가 -->
- [x] 🏗️ 빌드는 성공했나요? (yarn build)
- [x] 🧹 불필요한 코드는 제거했나요? e.g. console.log
- [x] 🙇‍♂️ 리뷰어를 지정했나요? 
- [x] 🏷️ 라벨은 등록했나요?

---

## ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 액세스 토큰 재발급 오류 hotfix
  - 여러 브라우저에서 로그인해서 리프레시 토큰이 바꼈을 경우, 40104에러가 내려오고 로그아웃 시켜야하는데 해당 로직이 제대로 동작하지 않아 로그아웃이 안되고 에러 뷰가 뜨는 오류 수정

